### PR TITLE
Preserve PDF layout and translated text styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pdf-translate.log
 .idea/
 Thumbs.db
 desktop.ini
+
+# Local contributor instructions; keep them out of the repository.
+/AGENTS.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -101,6 +101,12 @@ Copy each `src` value exactly. Preserve URLs, paths, identifiers, citation marke
 
 Formula and code placeholders such as `<b0></b0>` are immutable. Every opening and closing tag must retain the same identifier, count, and order as the source. The loader rejects a record whose placeholders differ, leaving that segment untranslated.
 
+Inline emphasis markers are immutable as balanced pairs: `<s1>...</s1>` is
+bold, `<s2>...</s2>` is italic, and `<s3>...</s3>` is bold italic. Complete
+style pairs may move with the translated phrase, but none may be dropped,
+duplicated, or cross-nested. Invalid style markup leaves the segment
+untranslated instead of silently losing emphasis.
+
 ### 3. Rebuild
 
 ```text

--- a/app/update.py
+++ b/app/update.py
@@ -8,7 +8,7 @@ for that, pointing at the release page is the whole feature.
 
 from __future__ import annotations
 
-APP_VERSION = "0.2.0"
+APP_VERSION = "0.2.1"
 REPOSITORY = "breslee1707/VI-Translate"
 RELEASES_API = f"https://api.github.com/repos/{REPOSITORY}/releases/latest"
 RELEASES_PAGE = f"https://github.com/{REPOSITORY}/releases/latest"

--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -1,8 +1,10 @@
 import concurrent.futures
 import logging
+import math
 import re
 import unicodedata
-from enum import Enum
+from collections.abc import Callable
+from enum import Enum, IntEnum
 from string import Template
 from typing import Dict
 
@@ -16,9 +18,146 @@ from pymupdf import Font
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from pdf2zh.rules import BULLET_CHARACTERS, is_formula_font, line_height_for_language
-from pdf2zh.translator import ENGINES, BaseTranslator
+from pdf2zh.translator import (
+    ENGINES,
+    BaseTranslator,
+    encode_formula_placeholders,
+    restore_formula_placeholders,
+)
 
 log = logging.getLogger(__name__)
+STYLE_TAG_PATTERN = re.compile(r"<(/?)s([123])>", re.IGNORECASE)
+IDENTITY_ORIENTATION = (1.0, 0.0, 0.0, 1.0)
+BASE14_STYLE_FONTS = {0: "tiro", 1: "tibo", 2: "tiit", 3: "tibi"}
+
+
+class TextStyle(IntEnum):
+    REGULAR = 0
+    BOLD = 1
+    ITALIC = 2
+    BOLD_ITALIC = 3
+
+
+def text_style_from_font(font_name: str | bytes) -> TextStyle:
+    """Infer PDF text emphasis from common PostScript font face names."""
+    if isinstance(font_name, bytes):
+        font_name = font_name.decode("utf-8", errors="ignore")
+    face = font_name.split("+")[-1]
+    bold = re.search(r"bold|semibold|demi|black|heavy", face, re.IGNORECASE)
+    italic = re.search(r"italic|oblique|slanted", face, re.IGNORECASE)
+    if bold and italic:
+        return TextStyle.BOLD_ITALIC
+    if bold:
+        return TextStyle.BOLD
+    if italic:
+        return TextStyle.ITALIC
+    return TextStyle.REGULAR
+
+
+def text_orientation(matrix) -> tuple[float, float, float, float] | None:
+    """Return the nearest quarter-turn text orientation, or None if arbitrary."""
+    a, b, c, d = (float(value) for value in matrix[:4])
+    x_scale = math.hypot(a, b)
+    y_scale = math.hypot(c, d)
+    if x_scale <= 1e-6 or y_scale <= 1e-6:
+        return None
+    normalised = (a / x_scale, b / x_scale, c / y_scale, d / y_scale)
+    candidates = (
+        IDENTITY_ORIENTATION,
+        (0.0, 1.0, -1.0, 0.0),
+        (-1.0, 0.0, 0.0, -1.0),
+        (0.0, -1.0, 1.0, 0.0),
+    )
+    return min(
+        candidates,
+        key=lambda candidate: sum(
+            (normalised[index] - candidate[index]) ** 2 for index in range(4)
+        ),
+    ) if min(
+        sum((normalised[index] - candidate[index]) ** 2 for index in range(4))
+        for candidate in candidates
+    ) <= 0.08 else None
+
+
+def normalised_text_matrix(matrix) -> tuple[float, float, float, float]:
+    a, b, c, d = (float(value) for value in matrix[:4])
+    x_scale = max(math.hypot(a, b), 1e-6)
+    y_scale = max(math.hypot(c, d), 1e-6)
+    return (a / x_scale, b / x_scale, c / y_scale, d / y_scale)
+
+
+def styled_text_matrix(
+    orientation: tuple[float, float, float, float],
+    style: int,
+    synthetic: bool,
+) -> tuple[float, float, float, float]:
+    """Compose an italic shear with the source orientation when needed."""
+    a, b, c, d = orientation
+    if synthetic and style in (TextStyle.ITALIC, TextStyle.BOLD_ITALIC):
+        shear = 0.2
+        c, d = c + a * shear, d + b * shear
+    return (a, b, c, d)
+
+
+def uses_synthetic_bold(style: int, synthetic: bool) -> bool:
+    return synthetic and style in (TextStyle.BOLD, TextStyle.BOLD_ITALIC)
+
+
+def matrix_font_size(matrix) -> float:
+    """Recover font size from a text matrix even when LTChar.size is advance."""
+    return math.hypot(float(matrix[0]), float(matrix[1]))
+
+
+def strip_style_tags(text: str) -> str:
+    return STYLE_TAG_PATTERN.sub("", text)
+
+
+def styled_character_text(characters: list[LTChar]) -> str:
+    """Serialize source character styles into translator-safe inline markers."""
+    parts: list[str] = []
+    active = TextStyle.REGULAR
+    for character in characters:
+        style = text_style_from_font(character.fontname)
+        if style != active:
+            if active:
+                parts.append(f"</s{int(active)}>")
+            if style:
+                parts.append(f"<s{int(style)}>")
+            active = style
+        parts.append(character.get_text())
+    if active:
+        parts.append(f"</s{int(active)}>")
+    return "".join(parts)
+
+
+def preferred_translation(text: str, language: str) -> str | None:
+    """Return stable Vietnamese terminology for the three rotated table headers."""
+    if language.lower() != "vi":
+        return None
+    visible = strip_style_tags(text).strip()
+    replacement = {
+        "Designation": "Tên gọi",
+        "Abbreviation": "Viết tắt",
+        "Unit": "Đơn vị",
+    }.get(visible)
+    if replacement is None:
+        return None
+    leading = re.match(r"^\s*", text).group(0)
+    trailing = re.search(r"\s*$", text).group(0)
+    style = re.fullmatch(r"\s*(<s[123]>).*?(</s[123]>)\s*", text, re.DOTALL)
+    if style:
+        return f"{leading}{style.group(1)}{replacement}{style.group(2)}{trailing}"
+    return f"{leading}{replacement}{trailing}"
+
+
+def should_translate_rotated_text(text: str) -> bool:
+    """Keep rotated document-control identifiers such as reference numbers."""
+    visible = strip_style_tags(text).strip()
+    if re.search(r"\d", visible) and re.search(
+        r"\b(ref|no|rev|code|version)\b", visible, re.IGNORECASE
+    ):
+        return False
+    return True
 
 
 class PDFConverterEx(PDFConverter):
@@ -87,7 +226,7 @@ class PDFConverterEx(PDFConverter):
 
 
 class Paragraph:
-    def __init__(self, y, x, x0, x1, y0, y1, size, brk):
+    def __init__(self, y, x, x0, x1, y0, y1, size, brk, cls=-1, matrix=None):
         self.y: float = y
         self.x: float = x
         self.x0: float = x0
@@ -96,6 +235,67 @@ class Paragraph:
         self.y1: float = y1
         self.size: float = size
         self.brk: bool = brk
+        self.cls: int = int(cls)
+        self.layout_bound: tuple[float, float, float, float] | None = None
+        self.orientation = text_orientation(matrix or (1, 0, 0, 1))
+        self.rotated_chars: list[LTChar] = []
+        self.open_style = TextStyle.REGULAR
+        self.text_length = 0
+        self.anchor: tuple[float, float] = (x, y)
+
+
+def text_fits_box_at_minimum_size(
+    text: str,
+    width: float,
+    height: float,
+    source_size: float,
+    formula_widths: list[float],
+    measure_char: Callable[[str, float], float],
+) -> bool:
+    """Conservatively check whether a cell translation can fit at 50% size."""
+    size = source_size * 0.5
+    if width <= 0 or height <= 0 or size <= 0:
+        return False
+
+    text = strip_style_tags(text)
+    chunks = re.findall(r"\{\s*v[\d\s]+\}|\S+|\s+", text, re.IGNORECASE)
+
+    def chunk_width(chunk: str) -> float:
+        marker = re.fullmatch(r"\{\s*v([\d\s]+)\}", chunk, re.IGNORECASE)
+        if marker:
+            try:
+                return formula_widths[int(marker.group(1).replace(" ", ""))]
+            except (IndexError, ValueError):
+                return 0.0
+        if chunk.isspace():
+            chunk = " "
+        return sum(measure_char(character, size) for character in chunk)
+
+    lines = 1
+    current = 0.0
+    for chunk in chunks:
+        measured = chunk_width(chunk)
+        is_formula = re.fullmatch(
+            r"\{\s*v([\d\s]+)\}", chunk, re.IGNORECASE
+        ) is not None
+        if is_formula and measured > width:
+            return False
+        if chunk.isspace():
+            if current:
+                current += measured
+            continue
+        if current and current + measured > width:
+            lines += 1
+            current = 0.0
+        if measured > width:
+            extra_lines = max(0, math.ceil(measured / width) - 1)
+            lines += extra_lines
+            current = measured - extra_lines * width
+        else:
+            current += measured
+
+    occupied_height = size + max(0, lines - 1) * size * 0.8
+    return occupied_height <= height + 0.01
 
 
 # fmt: off
@@ -115,14 +315,28 @@ class TranslateConverter(PDFConverterEx):
         envs: Dict = None,
         prompt: Template = None,
         ignore_cache: bool = False,
+        layout_bounds: Dict | None = None,
+        style_font_names: Dict | None = None,
+        style_fonts: Dict | None = None,
+        synthetic_styles: set[int] | None = None,
     ) -> None:
         super().__init__(rsrcmgr)
         self.vfont = vfont
         self.vchar = vchar
         self.thread = thread
         self.layout = layout
+        # high_level fills this mapping after the converter is constructed.
+        # Preserve an empty mapping by identity instead of replacing it.
+        self.layout_bounds = layout_bounds if layout_bounds is not None else {}
         self.noto_name = noto_name
         self.noto = noto
+        self.style_font_names = style_font_names or {0: noto_name}
+        self.style_fonts = style_fonts or {0: noto}
+        self.synthetic_styles = synthetic_styles or set()
+        self.output_fonts_by_name = {
+            self.style_font_names[style]: font
+            for style, font in self.style_fonts.items()
+        }
         self.translator: BaseTranslator = None
         self.scanned_pages: set = set()
         # Segments whose retries ran out; reported as a partial translation.
@@ -147,6 +361,14 @@ class TranslateConverter(PDFConverterEx):
             ignore_cache=ignore_cache,
         )
 
+    def record_translation_failure(self, segment: str, reason: str) -> None:
+        self.translation_failures.append(segment)
+        log.warning(
+            "Leaving segment in source language (%s): %r",
+            reason,
+            strip_style_tags(segment)[:200],
+        )
+
     def receive_layout(self, ltpage: LTPage):
         sstk: list[str] = []
         pstk: list[Paragraph] = []
@@ -163,6 +385,7 @@ class TranslateConverter(PDFConverterEx):
         xt_cls: int = -1
         vmax: float = ltpage.width / 4
         ops: str = ""
+        preserved_segments: set[str] = set()
 
         def vflag(font: str, char: str):
             if isinstance(font, bytes):
@@ -195,6 +418,49 @@ class TranslateConverter(PDFConverterEx):
                     return True
             return False
 
+        def close_style(index: int) -> None:
+            paragraph = pstk[index]
+            if paragraph.open_style:
+                sstk[index] += f"</s{int(paragraph.open_style)}>"
+                paragraph.open_style = TextStyle.REGULAR
+
+        def append_styled(index: int, text: str, style: TextStyle) -> None:
+            paragraph = pstk[index]
+            if style != paragraph.open_style:
+                close_style(index)
+                if style:
+                    sstk[index] += f"<s{int(style)}>"
+                paragraph.open_style = style
+            sstk[index] += text
+            paragraph.text_length += len(text)
+
+        def append_formula(index: int, identifier: int) -> None:
+            close_style(index)
+            sstk[index] += f"{{v{identifier}}}"
+
+        def new_paragraph(child: LTChar, cls: int) -> None:
+            orientation = text_orientation(child.matrix)
+            size = (
+                matrix_font_size(child.matrix)
+                if orientation not in (None, IDENTITY_ORIENTATION)
+                else child.size
+            )
+            sstk.append("")
+            pstk.append(
+                Paragraph(
+                    child.y0,
+                    child.x0,
+                    child.x0,
+                    child.x0,
+                    child.y0,
+                    child.y1,
+                    size,
+                    False,
+                    cls,
+                    child.matrix,
+                )
+            )
+
         ############################################################
         for child in ltpage:
             if isinstance(child, LTChar):
@@ -205,15 +471,25 @@ class TranslateConverter(PDFConverterEx):
                 cls = layout[cy, cx]
                 if child.get_text() in BULLET_CHARACTERS:
                     cls = 0
+                orientation = text_orientation(child.matrix)
                 if (
                     cls == 0
-                    or (cls == xt_cls and len(sstk[-1].strip()) > 1 and child.size < pstk[-1].size * 0.79)
+                    or (
+                        cls == xt_cls
+                        and pstk[-1].text_length > 1
+                        and orientation == IDENTITY_ORIENTATION
+                        and child.size < pstk[-1].size * 0.79
+                    )
                     or vflag(child.fontname, child.get_text())
-                    or (child.matrix[0] == 0 and child.matrix[3] == 0)
+                    or orientation is None
                 ):
                     cur_v = True
                 if not cur_v:
-                    if vstk and child.get_text() == "(":
+                    # Keep brackets with a formula only when the formula starts
+                    # the segment. In prose such as "Factor C1 (applies...)" a
+                    # subscript leaves vstk populated; capturing the following
+                    # bracket then strands it at its source coordinate.
+                    if vstk and not pstk[-1].text_length and child.get_text() == "(":
                         cur_v = True
                         vbkt += 1
                     if vbkt and child.get_text() == ")":
@@ -222,7 +498,7 @@ class TranslateConverter(PDFConverterEx):
                 if (
                     not cur_v
                     or cls != xt_cls
-                    or (sstk[-1] != "" and abs(child.x0 - xt.x0) > vmax)
+                    or (pstk[-1].text_length and abs(child.x0 - xt.x0) > vmax)
                 ):
                     if vstk:
                         if (
@@ -231,9 +507,9 @@ class TranslateConverter(PDFConverterEx):
                             and child.x0 > max([vch.x0 for vch in vstk])
                         ):
                             vfix = vstk[0].y0 - child.y0
-                        if sstk[-1] == "":
+                        if not pstk[-1].text_length:
                             xt_cls = -1
-                        sstk[-1] += f"{{v{len(var)}}}"
+                        append_formula(len(sstk) - 1, len(var))
                         var.append(vstk)
                         varl.append(vlstk)
                         varf.append(vfix)
@@ -247,24 +523,43 @@ class TranslateConverter(PDFConverterEx):
                         # it's likely a new list item, not a continuation
                         if (child.x1 < xt.x0
                             and abs(child.y0 - xt.y0) > pstk[-1].size * 1.5):
-                            sstk.append("")
-                            pstk.append(Paragraph(child.y0, child.x0, child.x0, child.x0, child.y0, child.y1, child.size, False))
+                            close_style(len(sstk) - 1)
+                            new_paragraph(child, cls)
                         elif child.x0 > xt.x1 + 1:
-                            sstk[-1] += " "
+                            if pstk[-1].orientation == IDENTITY_ORIENTATION:
+                                append_styled(
+                                    len(sstk) - 1,
+                                    " ",
+                                    text_style_from_font(child.fontname),
+                                )
                         elif child.x1 < xt.x0:
-                            sstk[-1] += " "
+                            if pstk[-1].orientation == IDENTITY_ORIENTATION:
+                                append_styled(
+                                    len(sstk) - 1,
+                                    " ",
+                                    text_style_from_font(child.fontname),
+                                )
                             pstk[-1].brk = True
                     else:
-                        sstk.append("")
-                        pstk.append(Paragraph(child.y0, child.x0, child.x0, child.x0, child.y0, child.y1, child.size, False))
+                        if sstk:
+                            close_style(len(sstk) - 1)
+                        new_paragraph(child, cls)
                 if not cur_v:
-                    if (
-                        child.size > pstk[-1].size
-                        or len(sstk[-1].strip()) == 1
-                    ) and child.get_text() != " ":
-                        pstk[-1].y -= child.size - pstk[-1].size
-                        pstk[-1].size = child.size
-                    sstk[-1] += child.get_text()
+                    if pstk[-1].orientation != IDENTITY_ORIENTATION:
+                        pstk[-1].rotated_chars.append(child)
+                        pstk[-1].text_length += len(child.get_text())
+                    else:
+                        if (
+                            child.size > pstk[-1].size
+                            or pstk[-1].text_length == 1
+                        ) and child.get_text() != " ":
+                            pstk[-1].y -= child.size - pstk[-1].size
+                            pstk[-1].size = child.size
+                        append_styled(
+                            len(sstk) - 1,
+                            child.get_text(),
+                            text_style_from_font(child.fontname),
+                        )
                 else:
                     if (
                         not vstk
@@ -293,10 +588,42 @@ class TranslateConverter(PDFConverterEx):
             else:
                 pass
         if vstk:
-            sstk[-1] += f"{{v{len(var)}}}"
+            append_formula(len(sstk) - 1, len(var))
             var.append(vstk)
             varl.append(vlstk)
             varf.append(vfix)
+
+        for index, paragraph in enumerate(pstk):
+            close_style(index)
+            if not paragraph.rotated_chars:
+                continue
+            a, b, _c, _d = paragraph.orientation
+            ordered = sorted(
+                paragraph.rotated_chars,
+                key=lambda character: (
+                    float(character.matrix[4]) * a
+                    + float(character.matrix[5]) * b
+                ),
+            )
+            sstk[index] = styled_character_text(ordered)
+            paragraph.text_length = sum(len(char.get_text()) for char in ordered)
+            first = ordered[0]
+            paragraph.anchor = (float(first.matrix[4]), float(first.matrix[5]))
+            paragraph.x, paragraph.y = paragraph.anchor
+            paragraph.size = matrix_font_size(first.matrix)
+            paragraph.brk = False
+            if not should_translate_rotated_text(sstk[index]):
+                preserved_segments.add(sstk[index])
+
+        page_bounds = self.layout_bounds.get(ltpage.pageid, {})
+        for paragraph in pstk:
+            bound = page_bounds.get(paragraph.cls)
+            if bound is None:
+                continue
+            paragraph.x0, paragraph.y0, paragraph.x1, paragraph.y1 = bound
+            if paragraph.orientation == IDENTITY_ORIENTATION:
+                paragraph.x = max(paragraph.x, paragraph.x0)
+            paragraph.layout_bound = bound
         log.debug("\n==========[VSTACK]==========\n")
         for id, v in enumerate(var):
             l = max([vch.x1 for vch in v]) - v[0].x0
@@ -314,11 +641,24 @@ class TranslateConverter(PDFConverterEx):
             stop=stop_after_attempt(8),
             reraise=True,
         )
-        def translate_segment(s: str) -> str:
+        def request_translation(s: str) -> str:
             return self.translator.translate(s)
 
+        def translate_segment(s: str) -> str:
+            preferred = preferred_translation(s, self.translator.lang_out)
+            if preferred is not None:
+                return preferred
+            encoded = encode_formula_placeholders(s)
+            translated = request_translation(encoded)
+            return restore_formula_placeholders(s, translated)
+
         def worker(s: str) -> str:
-            if not s.strip() or re.match(r"^\{v\d+\}$", s):
+            visible = strip_style_tags(s).strip()
+            if (
+                s in preserved_segments
+                or not visible
+                or re.fullmatch(r"\{v\d+\}", visible)
+            ):
                 return s
             try:
                 return translate_segment(s)
@@ -330,7 +670,7 @@ class TranslateConverter(PDFConverterEx):
                     log.exception(e)
                 else:
                     log.exception(e, exc_info=False)
-                self.translation_failures.append(s)
+                self.record_translation_failure(s, type(e).__name__)
                 return s
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=self.thread
@@ -339,12 +679,54 @@ class TranslateConverter(PDFConverterEx):
 
         ############################################################
         def raw_string(fcur: str, cstk: str):
-            if fcur == self.noto_name:
-                return "".join(["%04x" % self.noto.has_glyph(ord(c)) for c in cstk])
+            if fcur in self.output_fonts_by_name:
+                font = self.output_fonts_by_name[fcur]
+                return "".join(["%04x" % font.has_glyph(ord(c)) for c in cstk])
             elif isinstance(self.fontmap[fcur], PDFCIDFont):
                 return "".join(["%04x" % ord(c) for c in cstk])
             else:
                 return "".join(["%02x" % ord(c) for c in cstk])
+
+        def output_font(character: str, style: int, size: float) -> tuple[str, float]:
+            base_name = BASE14_STYLE_FONTS.get(style, "tiro")
+            try:
+                base = self.fontmap.get(base_name)
+                if base is not None and base.to_unichr(ord(character)) == character:
+                    return base_name, base.char_width(ord(character)) * size
+            except Exception:
+                pass
+            font_name = self.style_font_names.get(style, self.noto_name)
+            font = self.style_fonts.get(style, self.noto)
+            try:
+                return font_name, font.char_lengths(character, size)[0]
+            except Exception:
+                return font_name, size * 0.5
+
+        def measure_styled_text(text: str, size: float) -> float:
+            total = 0.0
+            style = TextStyle.REGULAR
+            pointer = 0
+            while pointer < len(text):
+                style_tag = STYLE_TAG_PATTERN.match(text, pointer)
+                if style_tag:
+                    closing, identifier = style_tag.groups()
+                    style = TextStyle.REGULAR if closing else TextStyle(int(identifier))
+                    pointer = style_tag.end()
+                    continue
+                formula = re.match(
+                    r"\{\s*v([\d\s]+)\}", text[pointer:], re.IGNORECASE
+                )
+                if formula:
+                    try:
+                        total += vlen[int(formula.group(1).replace(" ", ""))]
+                    except (IndexError, ValueError):
+                        pass
+                    pointer += len(formula.group(0))
+                    continue
+                _font_name, advance = output_font(text[pointer], int(style), size)
+                total += advance
+                pointer += 1
+            return total
 
         default_line_height = line_height_for_language(self.translator.lang_out)
         _x, _y = 0, 0
@@ -370,11 +752,152 @@ class TranslateConverter(PDFConverterEx):
                     fy1 = max(ch.y1 for ch in v) + pad
                     white_rects += f"q 1 1 1 rg {fx0:f} {fy0:f} {fx1-fx0:f} {fy1-fy0:f} re f Q "
 
-        def gen_op_txt(font, size, x, y, rtxt):
-            return f"/{font} {size:f} Tf 1 0 0 1 {x:f} {y:f} Tm [<{rtxt}>] TJ "
+        def gen_op_txt(
+            font,
+            size,
+            x,
+            y,
+            rtxt,
+            style=TextStyle.REGULAR,
+            orientation=IDENTITY_ORIENTATION,
+        ):
+            synthetic = int(style) in self.synthetic_styles
+            a, b, c, d = styled_text_matrix(orientation, int(style), synthetic)
+            render = ""
+            reset = ""
+            if uses_synthetic_bold(int(style), synthetic):
+                render = f"2 Tr {max(0.15, size * 0.025):f} w "
+                reset = "0 Tr "
+            return (
+                f"/{font} {size:f} Tf {render}{a:f} {b:f} {c:f} {d:f} "
+                f"{x:f} {y:f} Tm [<{rtxt}>] TJ {reset}"
+            )
 
         def gen_op_line(x, y, xlen, ylen, linewidth):
             return f"ET q 1 0 0 1 {x:f} {y:f} cm [] 0 d 0 J {linewidth:f} w 0 0 m {xlen:f} {ylen:f} l S Q BT "
+
+        def rotated_available_length(paragraph: Paragraph) -> float:
+            a, b, _c, _d = paragraph.orientation
+            bounds = paragraph.layout_bound or (
+                paragraph.x0,
+                paragraph.y0,
+                paragraph.x1,
+                paragraph.y1,
+            )
+            x0, y0, x1, y1 = bounds
+            projections = [
+                x * a + y * b
+                for x, y in ((x0, y0), (x0, y1), (x1, y0), (x1, y1))
+            ]
+            anchor_projection = paragraph.anchor[0] * a + paragraph.anchor[1] * b
+            return max(0.0, max(projections) - anchor_projection)
+
+        def render_rotated_text(
+            paragraph: Paragraph,
+            source: str,
+            translated: str,
+        ) -> list[str]:
+            size = paragraph.size
+            available = rotated_available_length(paragraph)
+            measured = measure_styled_text(translated, size)
+            if measured > available * 1.05 and available > 0:
+                ratio = available / measured
+                if ratio < 0.5:
+                    if translated != source:
+                        self.record_translation_failure(
+                            source, "rotated text needs less than 50% font size"
+                        )
+                    translated = source
+                    measured = measure_styled_text(translated, size)
+                    ratio = min(1.0, available / measured) if measured else 1.0
+                size *= max(0.5, min(1.0, ratio))
+
+            a, b, _c, _d = paragraph.orientation
+            anchor_x, anchor_y = paragraph.anchor
+            cursor = 0.0
+            pointer = 0
+            active_style = TextStyle.REGULAR
+            run_font: str | None = None
+            run_style = TextStyle.REGULAR
+            run_text = ""
+            run_start = 0.0
+            operations: list[str] = []
+
+            def flush() -> None:
+                nonlocal run_text
+                if not run_text or run_font is None:
+                    run_text = ""
+                    return
+                operations.append(
+                    gen_op_txt(
+                        run_font,
+                        size,
+                        anchor_x + a * run_start,
+                        anchor_y + b * run_start,
+                        raw_string(run_font, run_text),
+                        run_style,
+                        paragraph.orientation,
+                    )
+                )
+                run_text = ""
+
+            while pointer < len(translated):
+                style_tag = STYLE_TAG_PATTERN.match(translated, pointer)
+                if style_tag:
+                    flush()
+                    closing, identifier = style_tag.groups()
+                    active_style = (
+                        TextStyle.REGULAR
+                        if closing
+                        else TextStyle(int(identifier))
+                    )
+                    pointer = style_tag.end()
+                    continue
+                formula = re.match(
+                    r"\{\s*v([\d\s]+)\}", translated[pointer:], re.IGNORECASE
+                )
+                if formula:
+                    flush()
+                    try:
+                        vid = int(formula.group(1).replace(" ", ""))
+                        formula_chars = var[vid]
+                    except (IndexError, ValueError):
+                        pointer += len(formula.group(0))
+                        continue
+                    first = formula_chars[0]
+                    first_origin = (float(first.matrix[4]), float(first.matrix[5]))
+                    for formula_char in formula_chars:
+                        dx = float(formula_char.matrix[4]) - first_origin[0]
+                        dy = float(formula_char.matrix[5]) - first_origin[1]
+                        operations.append(
+                            gen_op_txt(
+                                self.fontid[formula_char.font],
+                                matrix_font_size(formula_char.matrix),
+                                anchor_x + a * cursor + dx,
+                                anchor_y + b * cursor + dy,
+                                raw_string(
+                                    self.fontid[formula_char.font],
+                                    chr(formula_char.cid),
+                                ),
+                                TextStyle.REGULAR,
+                                normalised_text_matrix(formula_char.matrix),
+                            )
+                        )
+                    cursor += vlen[vid]
+                    pointer += len(formula.group(0))
+                    continue
+                character = translated[pointer]
+                font_name, advance = output_font(character, int(active_style), size)
+                if font_name != run_font or active_style != run_style:
+                    flush()
+                    run_font = font_name
+                    run_style = active_style
+                    run_start = cursor
+                run_text += character
+                cursor += advance
+                pointer += 1
+            flush()
+            return operations
 
         for id, new in enumerate(news):
             x: float = pstk[id].x
@@ -385,18 +908,58 @@ class TranslateConverter(PDFConverterEx):
             size: float = pstk[id].size
             brk: bool = pstk[id].brk
 
-            # Auto-scale font size if translation is longer than original
-            # Calculate actual rendered width of translated text at current size
-            if brk and new != sstk[id]:
+            if pstk[id].orientation not in (None, IDENTITY_ORIENTATION):
+                ops_list.extend(render_rotated_text(pstk[id], sstk[id], new))
+                continue
+
+            if pstk[id].layout_bound is not None and new != sstk[id]:
+                def _cell_measure(character: str, candidate_size: float) -> float:
+                    return max(
+                        output_font(character, style, candidate_size)[1]
+                        for style in self.style_font_names
+                    )
+
+                if not text_fits_box_at_minimum_size(
+                    new,
+                    x1 - x0,
+                    height,
+                    size,
+                    vlen,
+                    _cell_measure,
+                ):
+                    self.record_translation_failure(
+                        sstk[id], "table cell cannot fit at 50% font size"
+                    )
+                    new = sstk[id]
+
+            # Auto-scale translated text to the footprint of the source. This is
+            # also required for a single-line title: without it a longer target
+            # string ignores x1 completely and runs into the neighbouring column.
+            if new != sstk[id]:
                 line_width = x1 - x0
                 # Count how many lines the original text occupied
-                orig_lines = max(1, round(height / (pstk[id].size * default_line_height)))
+                orig_lines = (
+                    max(1, round(height / (pstk[id].size * default_line_height)))
+                    if brk
+                    else 1
+                )
                 total_avail = line_width * orig_lines
                 # Measure actual width of translated text (excluding formula tags)
                 total_new_width = 0
                 tmp_ptr = 0
                 plain_new = new
+                measure_style = TextStyle.REGULAR
                 while tmp_ptr < len(plain_new):
+                    style_tag = STYLE_TAG_PATTERN.match(plain_new, tmp_ptr)
+                    if style_tag:
+                        closing, identifier = style_tag.groups()
+                        measure_style = (
+                            TextStyle.REGULAR
+                            if closing
+                            else TextStyle(int(identifier))
+                        )
+                        tmp_ptr = style_tag.end()
+                        continue
                     vm = re.match(r"\{\s*v([\d\s]+)\}", plain_new[tmp_ptr:], re.IGNORECASE)
                     if vm:
                         try:
@@ -407,37 +970,42 @@ class TranslateConverter(PDFConverterEx):
                         tmp_ptr += len(vm.group(0))
                     else:
                         ch = plain_new[tmp_ptr]
-                        try:
-                            if self.fontmap.get("tiro") and self.fontmap["tiro"].to_unichr(ord(ch)) == ch:
-                                total_new_width += self.fontmap["tiro"].char_width(ord(ch)) * pstk[id].size
-                            else:
-                                total_new_width += self.noto.char_lengths(ch, pstk[id].size)[0]
-                        except Exception:
-                            total_new_width += pstk[id].size * 0.5
+                        total_new_width += output_font(
+                            ch, int(measure_style), pstk[id].size
+                        )[1]
                         tmp_ptr += 1
                 if total_avail > 0 and total_new_width > total_avail * 1.05:
                     ratio = total_avail / total_new_width
-                    size = pstk[id].size * max(ratio, 0.5)  # don't go below 50%
+                    if not brk and ratio < 0.5:
+                        self.record_translation_failure(
+                            sstk[id], "single line needs less than 50% font size"
+                        )
+                        new = sstk[id]
+                    else:
+                        size = pstk[id].size * max(ratio, 0.5)
 
             # Pre-compute word-boundary line breaks to avoid mid-word splits
             if brk:
-                def _measure_char(c):
-                    try:
-                        if self.fontmap.get("tiro") and self.fontmap["tiro"].to_unichr(ord(c)) == c:
-                            return self.fontmap["tiro"].char_width(ord(c)) * size
-                    except Exception:
-                        pass
-                    try:
-                        return self.noto.char_lengths(c, size)[0]
-                    except Exception:
-                        return size * 0.5
+                def _measure_char(c, style):
+                    return output_font(c, int(style), size)[1]
 
                 break_positions = set()
                 cur_x = x
                 last_space_ptr = -1
                 last_space_x_after = cur_x
                 p2 = 0
+                wrap_style = TextStyle.REGULAR
                 while p2 < len(new):
+                    style_tag = STYLE_TAG_PATTERN.match(new, p2)
+                    if style_tag:
+                        closing, identifier = style_tag.groups()
+                        wrap_style = (
+                            TextStyle.REGULAR
+                            if closing
+                            else TextStyle(int(identifier))
+                        )
+                        p2 = style_tag.end()
+                        continue
                     vr2 = re.match(r"\{\s*v([\d\s]+)\}", new[p2:], re.IGNORECASE)
                     if vr2:
                         try:
@@ -455,7 +1023,7 @@ class TranslateConverter(PDFConverterEx):
                         p2 += len(vr2.group(0))
                     else:
                         ch2 = new[p2]
-                        cw = _measure_char(ch2)
+                        cw = _measure_char(ch2, wrap_style)
                         if ch2 == ' ':
                             last_space_ptr = p2
                             last_space_x_after = cur_x + cw
@@ -477,11 +1045,35 @@ class TranslateConverter(PDFConverterEx):
             tx = x
             fcur_ = fcur
             ptr = 0
+            active_style = TextStyle.REGULAR
+            cstyle = TextStyle.REGULAR
             log.debug(f"< {y} {x} {x0} {x1} {size} {brk} > {sstk[id]} | {new}")
 
             ops_vals: list[dict] = []
 
             while ptr < len(new):
+                style_tag = STYLE_TAG_PATTERN.match(new, ptr)
+                if style_tag:
+                    if cstk:
+                        ops_vals.append({
+                            "type": OpType.TEXT,
+                            "font": fcur,
+                            "size": size,
+                            "x": tx,
+                            "dy": 0,
+                            "rtxt": raw_string(fcur, cstk),
+                            "lidx": lidx,
+                            "style": cstyle,
+                        })
+                        cstk = ""
+                    closing, identifier = style_tag.groups()
+                    active_style = (
+                        TextStyle.REGULAR
+                        if closing
+                        else TextStyle(int(identifier))
+                    )
+                    ptr = style_tag.end()
+                    continue
                 vy_regex = re.match(
                     r"\{\s*v([\d\s]+)\}", new[ptr:], re.IGNORECASE
                 )
@@ -506,25 +1098,15 @@ class TranslateConverter(PDFConverterEx):
                                 "x": tx,
                                 "dy": 0,
                                 "rtxt": raw_string(fcur, cstk),
-                                "lidx": lidx
+                                "lidx": lidx,
+                                "style": cstyle,
                             })
                             cstk = ""
                         x = x0
                         lidx += 1
                         ptr += 1
                         continue
-                    fcur_ = None
-                    try:
-                        if fcur_ is None and self.fontmap["tiro"].to_unichr(ord(ch)) == ch:
-                            fcur_ = "tiro"
-                    except Exception:
-                        pass
-                    if fcur_ is None:
-                        fcur_ = self.noto_name
-                    if fcur_ == self.noto_name: # FIXME: change to CONST
-                        adv = self.noto.char_lengths(ch, size)[0]
-                    else:
-                        adv = self.fontmap[fcur_].char_width(ord(ch)) * size
+                    fcur_, adv = output_font(ch, int(active_style), size)
                     ptr += 1
                 if (
                     fcur_ != fcur
@@ -545,7 +1127,8 @@ class TranslateConverter(PDFConverterEx):
                                     "x": tx,
                                     "dy": 0,
                                     "rtxt": raw_string(fcur, before),
-                                    "lidx": lidx
+                                    "lidx": lidx,
+                                    "style": cstyle,
                                 })
                             # Move remainder to new line
                             lidx += 1
@@ -553,10 +1136,7 @@ class TranslateConverter(PDFConverterEx):
                             tx = x
                             # Recalculate x for the remaining text
                             for rc in after:
-                                if fcur == self.noto_name:
-                                    x += self.noto.char_lengths(rc, size)[0]
-                                else:
-                                    x += self.fontmap[fcur].char_width(ord(rc)) * size
+                                x += output_font(rc, int(cstyle), size)[1]
                             cstk = after
                         else:
                             ops_vals.append({
@@ -566,7 +1146,8 @@ class TranslateConverter(PDFConverterEx):
                                 "x": tx,
                                 "dy": 0,
                                 "rtxt": raw_string(fcur, cstk),
-                                "lidx": lidx
+                                "lidx": lidx,
+                                "style": cstyle,
                             })
                             cstk = ""
                 if brk and x + adv > x1 + 0.1 * size:
@@ -585,7 +1166,9 @@ class TranslateConverter(PDFConverterEx):
                             "x": x + vch.x0 - var[vid][0].x0,
                             "dy": fix + vch.y0 - var[vid][0].y0,
                             "rtxt": raw_string(self.fontid[vch.font], vc),
-                            "lidx": lidx
+                            "lidx": lidx,
+                            "style": TextStyle.REGULAR,
+                            "orientation": normalised_text_matrix(vch.matrix),
                         })
                         if log.isEnabledFor(logging.DEBUG):
                             lstk.append(LTLine(0.1, (_x, _y), (x + vch.x0 - var[vid][0].x0, fix + y + vch.y0 - var[vid][0].y0)))
@@ -604,6 +1187,7 @@ class TranslateConverter(PDFConverterEx):
                 else:
                     if not cstk:
                         tx = x
+                        cstyle = active_style
                         if x == x0 and ch == " ":
                             adv = 0
                         else:
@@ -624,7 +1208,8 @@ class TranslateConverter(PDFConverterEx):
                     "x": tx,
                     "dy": 0,
                     "rtxt": raw_string(fcur, cstk),
-                    "lidx": lidx
+                    "lidx": lidx,
+                    "style": cstyle,
                 })
 
             # An inline formula keeps the vertical offsets it had in the source,
@@ -666,7 +1251,17 @@ class TranslateConverter(PDFConverterEx):
 
             for vals in ops_vals:
                 if vals["type"] == OpType.TEXT:
-                    ops_list.append(gen_op_txt(vals["font"], vals["size"], vals["x"], vals["dy"] + y - offsets[vals["lidx"]], vals["rtxt"]))
+                    ops_list.append(
+                        gen_op_txt(
+                            vals["font"],
+                            vals["size"],
+                            vals["x"],
+                            vals["dy"] + y - offsets[vals["lidx"]],
+                            vals["rtxt"],
+                            vals.get("style", TextStyle.REGULAR),
+                            vals.get("orientation", IDENTITY_ORIENTATION),
+                        )
+                    )
                 elif vals["type"] == OpType.LINE:
                     ops_list.append(gen_op_line(vals["x"], vals["dy"] + y - offsets[vals["lidx"]], vals["xlen"], vals["ylen"], vals["linewidth"]))
 
@@ -700,7 +1295,7 @@ def line_offsets(
         for i in range(lines)
     ]
     total = sum(want)
-    if budget is not None and total > budget:
+    if budget is not None and total > 0 and total > budget:
         # Not enough slack for every tall formula. Share out what there is
         # rather than growing the paragraph down over the text below it.
         scale = max(0.0, budget) / total

--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -26,11 +26,48 @@ from pymupdf import Document, Font
 from pdf2zh.converter import TranslateConverter
 from pdf2zh.doclayout import OnnxModel
 from pdf2zh.pdfinterp import PDFPageInterpreterEx
-from pdf2zh.rules import classify_preserved_page, is_scanned_page
+from pdf2zh.rules import (
+    classify_preserved_page,
+    cluster_table_words,
+    formula_regions,
+    is_scanned_page,
+    matching_table_cells,
+    should_translate_table_cell,
+)
 
 NOTO_NAME = "noto"
+STYLE_FONT_NAMES = {
+    0: NOTO_NAME,
+    1: "noto-bold",
+    2: "noto-italic",
+    3: "noto-bolditalic",
+}
+BASE14_STYLE_FONTS = {0: "tiro", 1: "tibo", 2: "tiit", 3: "tibi"}
 
 logger = logging.getLogger(__name__)
+
+
+def output_style_font_paths(language: str, regular_path: str) -> dict[int, str]:
+    """Resolve regular/bold/italic/bold-italic fonts for translated prose.
+
+    Vietnamese desktop builds run on Windows, where Times New Roman ships with
+    all four faces. Other environments retain the existing Unicode font and let
+    the converter synthesize missing weight/slant instead of downloading a new
+    family at render time.
+    """
+    regular = str(Path(regular_path))
+    result = {style: regular for style in STYLE_FONT_NAMES}
+    if Path(regular).name.lower() != "times.ttf":
+        return result
+    windows_variants = {
+        1: Path("C:/Windows/Fonts/timesbd.ttf"),
+        2: Path("C:/Windows/Fonts/timesi.ttf"),
+        3: Path("C:/Windows/Fonts/timesbi.ttf"),
+    }
+    for style, path in windows_variants.items():
+        if path.is_file():
+            result[style] = str(path)
+    return result
 
 noto_list = [
     "am",  # Amharic
@@ -84,10 +121,14 @@ def translate_patch(
     envs: Dict = None,
     prompt: Template = None,
     ignore_cache: bool = False,
+    style_font_names: Dict | None = None,
+    style_fonts: Dict | None = None,
+    synthetic_styles: set[int] | None = None,
     **kwarg: Any,
 ) -> None:
     rsrcmgr = PDFResourceManager()
     layout = {}
+    layout_bounds = {}
     scanned_pages = set()
     device = TranslateConverter(
         rsrcmgr,
@@ -103,6 +144,10 @@ def translate_patch(
         envs,
         prompt,
         ignore_cache,
+        layout_bounds,
+        style_font_names,
+        style_fonts,
+        synthetic_styles,
     )
 
     assert device is not None
@@ -138,6 +183,7 @@ def translate_patch(
             box = np.ones((pix.height, pix.width))
             h, w = box.shape
             vcls = ["abandon", "figure", "table", "isolate_formula", "formula_caption"]
+            model_table_bounds = []
             # Process non-vcls boxes in ascending confidence order so that
             # higher-confidence boxes overwrite lower-confidence ones
             non_vcls_boxes = [
@@ -154,8 +200,16 @@ def translate_patch(
                 )
                 box[y0:y1, x0:x1] = i + 2
             for i, d in enumerate(page_layout.boxes):
-                if page_layout.names[int(d.cls)] in vcls:
-                    x0, y0, x1, y1 = d.xyxy.squeeze()
+                name = page_layout.names[int(d.cls)]
+                if name in vcls:
+                    raw_x0, raw_y0, raw_x1, raw_y1 = (
+                        float(value) for value in d.xyxy.squeeze()
+                    )
+                    if name == "table":
+                        model_table_bounds.append(
+                            (raw_x0, raw_y0, raw_x1, raw_y1)
+                        )
+                    x0, y0, x1, y1 = raw_x0, raw_y0, raw_x1, raw_y1
                     x0, y0, x1, y1 = (
                         np.clip(int(x0 - 1), 0, w - 1),
                         np.clip(int(h - y1 - 1), 0, h - 1),
@@ -163,6 +217,85 @@ def translate_patch(
                         np.clip(int(h - y0 + 1), 0, h - 1),
                     )
                     box[y0:y1, x0:x1] = 0
+
+            # A model-detected table stays protected unless PyMuPDF can split
+            # that same region into cells. Each reliable cell gets its own class
+            # so its text is translated independently while the original grid,
+            # fills and borders remain untouched.
+            source_page = doc_zh[page.pageno]
+            try:
+                detected_tables = source_page.find_tables().tables
+            except Exception as error:
+                logger.warning(
+                    "Page %s table-cell detection failed; preserving tables: %s",
+                    pageno + 1,
+                    error,
+                )
+                detected_tables = []
+            next_class = len(page_layout.boxes) + 2
+            page_bounds = layout_bounds.setdefault(page.pageno, {})
+            page_height = float(page_rect.height)
+            page_words = source_page.get_text("words", sort=True)
+            for table_bounds in model_table_bounds:
+                for cell in matching_table_cells(table_bounds, detected_tables):
+                    cx0 = max(float(cell[0]), table_bounds[0])
+                    cy0 = max(float(cell[1]), table_bounds[1])
+                    cx1 = min(float(cell[2]), table_bounds[2])
+                    cy1 = min(float(cell[3]), table_bounds[3])
+                    if cx1 - cx0 <= 4 or cy1 - cy0 <= 1:
+                        continue
+                    cell_words = [
+                        word
+                        for word in page_words
+                        if cx0 <= (float(word[0]) + float(word[2])) / 2 <= cx1
+                        and cy0 <= (float(word[1]) + float(word[3])) / 2 <= cy1
+                    ]
+                    for cluster in cluster_table_words(
+                        cell_words, (cx0, cy0, cx1, cy1)
+                    ):
+                        if not should_translate_table_cell(cluster.text):
+                            continue
+                        for word in cluster.words:
+                            wx0, wy0, wx1, wy1 = (
+                                float(value) for value in word[:4]
+                            )
+                            px0, py0, px1, py1 = (
+                                np.clip(int(wx0 - 1), 0, w - 1),
+                                np.clip(int(h - wy1 - 1), 0, h - 1),
+                                np.clip(int(wx1 + 1), 0, w - 1),
+                                np.clip(int(h - wy0 + 1), 0, h - 1),
+                            )
+                            box[py0:py1, px0:px1] = next_class
+                        bx0, by0, bx1, by1 = cluster.bbox
+                        content_y0 = min(by0, *(float(word[1]) for word in cluster.words))
+                        content_y1 = max(by1, *(float(word[3]) for word in cluster.words))
+                        padded = (
+                            bx0 + 2.0,
+                            page_height - content_y1,
+                            bx1 - 2.0,
+                            page_height - content_y0,
+                        )
+                        if padded[2] > padded[0] and padded[3] > padded[1]:
+                            page_bounds[next_class] = padded
+                        next_class += 1
+
+            # Technical documents often use ordinary prose fonts for equations.
+            # Protect operator-only blocks and stacked identifiers before the
+            # converter can reflow them. A one-point pad catches their rules and
+            # small subscripts without swallowing adjacent prose.
+            fallback_formulas = formula_regions(
+                source_page.get_text("blocks", sort=True),
+                page_words,
+                stacked_exclusions=model_table_bounds,
+            )
+            for fx0, fy0, fx1, fy1 in fallback_formulas:
+                bx0, by0, bx1, by1 = (
+                    np.clip(int(fx0 - 1), 0, w - 1),
+                    np.clip(int(h - fy1 - 1), 0, h - 1),
+                    np.clip(int(fx1 + 1), 0, w - 1),
+                    np.clip(int(h - fy0 + 1), 0, h - 1),
+                )
+                box[by0:by1, bx0:bx1] = 0
 
             # Detect TOC pages by analyzing extracted text patterns
             page_text = doc_zh[page.pageno].get_text("text")
@@ -311,12 +444,22 @@ def translate_stream(
     ignore_cache: bool = False,
     **kwarg: Any,
 ):
-    font_list = [("tiro", None)]
-
     font_path = download_remote_fonts(lang_out.lower())
+    style_paths = output_style_font_paths(lang_out.lower(), font_path)
+    style_font_names = dict(STYLE_FONT_NAMES)
+    style_fonts = {
+        style: Font(style_font_names[style], path)
+        for style, path in style_paths.items()
+    }
+    synthetic_styles = {
+        style for style, path in style_paths.items() if style and path == style_paths[0]
+    }
+    font_list = [(name, None) for name in BASE14_STYLE_FONTS.values()]
     noto_name = NOTO_NAME
-    noto = Font(noto_name, font_path)
-    font_list.append((noto_name, font_path))
+    noto = style_fonts[0]
+    font_list.extend(
+        (style_font_names[style], path) for style, path in style_paths.items()
+    )
 
     doc_en = Document(stream=stream)
     stream = io.BytesIO()

--- a/pdf2zh/rules.py
+++ b/pdf2zh/rules.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from statistics import median
 from typing import Any
 
 FORMULA_FONT_PATTERN = re.compile(
@@ -12,6 +13,14 @@ FORMULA_FONT_PATTERN = re.compile(
     r"stmary|.*Mono|.*Code|.*Sym|.*Math|.*Typewriter|Cousine|Consolas|Menlo|"
     r"Monaco|Inconsolata|Source.?Code|Fira.?Code|DejaVu.?Sans.?Mono|"
     r"Liberation.?Mono|Courier)"
+)
+
+MATH_OPERATOR_PATTERN = re.compile(
+    r"[=≤≥≈≠±×÷·∑∫√∞∝+*/^]"
+)
+PROSE_WORD_PATTERN = re.compile(r"[a-z]{3,}")
+STACKED_TOKEN_PATTERN = re.compile(
+    r"[A-Za-z\u0370-\u03ff][A-Za-z\u0370-\u03ff0-9%]*"
 )
 
 BULLET_CHARACTERS = frozenset(
@@ -43,6 +52,15 @@ class PreservationDecision:
     detail: str
 
 
+@dataclass(frozen=True)
+class TableTextCluster:
+    """A visual text group inside a table cell, separated from codes/units."""
+
+    bbox: tuple[float, float, float, float]
+    text: str
+    words: tuple[Sequence[Any], ...]
+
+
 def is_formula_font(font_name: str) -> bool:
     """Return whether a font name marks formula or code text."""
     return FORMULA_FONT_PATTERN.match(font_name) is not None
@@ -51,6 +69,272 @@ def is_formula_font(font_name: str) -> bool:
 def line_height_for_language(language: str) -> float:
     """Return the translation line-height multiplier for a target language."""
     return LANGUAGE_LINE_HEIGHT.get(language.lower(), 1.1)
+
+
+def _rect(value: Sequence[Any]) -> tuple[float, float, float, float] | None:
+    if len(value) < 4:
+        return None
+    try:
+        return tuple(float(item) for item in value[:4])
+    except (TypeError, ValueError):
+        return None
+
+
+def _inside_any(
+    rectangle: tuple[float, float, float, float],
+    regions: Iterable[Sequence[Any]],
+) -> bool:
+    x0, y0, x1, y1 = rectangle
+    cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
+    for region in regions:
+        bounds = _rect(region)
+        if bounds is None:
+            continue
+        rx0, ry0, rx1, ry1 = bounds
+        if rx0 <= cx <= rx1 and ry0 <= cy <= ry1:
+            return True
+    return False
+
+
+def formula_regions(
+    blocks: Iterable[Sequence[Any]],
+    words: Iterable[Sequence[Any]],
+    *,
+    stacked_exclusions: Iterable[Sequence[Any]] = (),
+) -> list[tuple[float, float, float, float]]:
+    """Return ordinary-font regions whose exact mathematical layout must survive.
+
+    The layout model catches dedicated formula fonts well, but technical PDFs
+    often typeset equations in the same font as their prose. Operator-heavy
+    blocks without prose words are equations. A second geometry rule catches an
+    inline stacked fraction such as F1/b0 even when it sits inside a prose block.
+    """
+    protected: list[tuple[float, float, float, float]] = []
+    for block in blocks:
+        bounds = _rect(block)
+        if bounds is None or len(block) < 5:
+            continue
+        compact = " ".join(str(block[4]).split())
+        if (
+            compact
+            and MATH_OPERATOR_PATTERN.search(compact)
+            and PROSE_WORD_PATTERN.search(compact) is None
+        ):
+            protected.append(bounds)
+
+    candidates = list(words)
+    exclusions = tuple(stacked_exclusions)
+    for index, upper in enumerate(candidates):
+        upper_bounds = _rect(upper)
+        if upper_bounds is None or len(upper) < 8:
+            continue
+        upper_text = str(upper[4])
+        if (
+            len(upper_text) > 4
+            or STACKED_TOKEN_PATTERN.fullmatch(upper_text) is None
+            or not any(character.isdigit() for character in upper_text)
+            or _inside_any(upper_bounds, exclusions)
+        ):
+            continue
+        ux0, uy0, ux1, uy1 = upper_bounds
+        for lower in candidates[index + 1 :]:
+            lower_bounds = _rect(lower)
+            if lower_bounds is None or len(lower) < 8:
+                continue
+            if upper[5] != lower[5] or upper[6] == lower[6]:
+                continue
+            lower_text = str(lower[4])
+            if (
+                len(lower_text) > 4
+                or STACKED_TOKEN_PATTERN.fullmatch(lower_text) is None
+                or not any(character.isdigit() for character in lower_text)
+                or _inside_any(lower_bounds, exclusions)
+            ):
+                continue
+            lx0, ly0, lx1, ly1 = lower_bounds
+            overlap = max(0.0, min(ux1, lx1) - max(ux0, lx0))
+            smaller_width = min(ux1 - ux0, lx1 - lx0)
+            centre_gap = abs((uy0 + uy1) / 2 - (ly0 + ly1) / 2)
+            max_height = max(uy1 - uy0, ly1 - ly0)
+            if (
+                smaller_width > 0
+                and overlap / smaller_width >= 0.6
+                and 2 < centre_gap <= 1.5 * max_height
+            ):
+                protected.append(
+                    (
+                        min(ux0, lx0),
+                        min(uy0, ly0),
+                        max(ux1, lx1),
+                        max(uy1, ly1),
+                    )
+                )
+    return protected
+
+
+def matching_table_cells(
+    model_bounds: Sequence[Any],
+    tables: Iterable[Any],
+    *,
+    minimum_overlap: float = 0.5,
+) -> list[tuple[float, float, float, float]]:
+    """Return cells from the table whose area covers a model table detection.
+
+    The model is the gate: PyMuPDF cell detection only enables translation when
+    it can explain at least half of that already-recognised table. Unmatched
+    tables keep the old, fully protected behaviour.
+    """
+    model = _rect(model_bounds)
+    if model is None:
+        return []
+    mx0, my0, mx1, my1 = model
+    model_area = max(0.0, mx1 - mx0) * max(0.0, my1 - my0)
+    if model_area <= 0:
+        return []
+
+    best: Any = None
+    best_overlap = 0.0
+    for table in tables:
+        bounds = _rect(getattr(table, "bbox", ()))
+        if bounds is None:
+            continue
+        tx0, ty0, tx1, ty1 = bounds
+        intersection = max(0.0, min(mx1, tx1) - max(mx0, tx0)) * max(
+            0.0, min(my1, ty1) - max(my0, ty0)
+        )
+        overlap = intersection / model_area
+        if overlap > best_overlap:
+            best, best_overlap = table, overlap
+    if best is None or best_overlap < minimum_overlap:
+        return []
+
+    cells: list[tuple[float, float, float, float]] = []
+    for cell in getattr(best, "cells", ()):
+        bounds = _rect(cell)
+        if bounds is None:
+            continue
+        x0, y0, x1, y1 = bounds
+        cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
+        if mx0 <= cx <= mx1 and my0 <= cy <= my1 and bounds not in cells:
+            cells.append(bounds)
+    return cells
+
+
+def should_translate_table_cell(text: str) -> bool:
+    """Return whether a cell contains natural-language text rather than codes.
+
+    Product identifiers and numeric cells are safer left as original PDF glyphs.
+    Natural-language labels in the supported source documents contain lowercase
+    letters, including Unicode lowercase letters outside English.
+    """
+    value = " ".join(text.split())
+    if not value:
+        return False
+
+    def natural_token(token: str) -> bool:
+        token = token.strip("()[]{}:;,\"'“”")
+        letters = "".join(character for character in token if character.isalpha())
+        if token.lower() in {"dry", "wet"}:
+            return True
+        if token.lower() in {"max", "min"}:
+            return False
+        if re.search(r"[\u0370-\u03ff]", token):
+            return False
+        if len(letters) <= 2:
+            return False
+        if letters.isupper():
+            return False
+        if (
+            any(character.isdigit() for character in token)
+            or re.search(r"[a-z][A-Z]", token)
+            or sum(character.isupper() for character in letters) >= 2
+            or re.search(r"[%._/·]", token)
+        ):
+            return False
+        if len(letters) <= 3 and letters[:1].isupper():
+            return False
+        return any(character.islower() for character in letters)
+
+    return any(natural_token(token) for token in value.split())
+
+
+def cluster_table_words(
+    words: Iterable[Sequence[Any]],
+    cell: Sequence[Any],
+) -> list[TableTextCluster]:
+    """Split a visually merged table cell into prose and code-like x clusters.
+
+    Some PDFs omit the rule between a description and its abbreviation column,
+    so PyMuPDF returns both as one cell. Normal word spaces are small; the jump
+    to a right-aligned code is much larger. X-overlap across wrapped lines keeps
+    multi-line descriptions together.
+    """
+    bounds = _rect(cell)
+    items = [word for word in words if _rect(word) is not None and len(word) >= 5]
+    if bounds is None or not items:
+        return []
+
+    heights = [max(0.1, float(word[3]) - float(word[1])) for word in items]
+    gap_limit = max(3.0, median(heights) * 0.6)
+    groups: list[list[Sequence[Any]]] = []
+    group_bounds: list[list[float]] = []
+    for word in sorted(items, key=lambda item: (float(item[0]), float(item[1]))):
+        x0, y0, x1, y1 = (float(value) for value in word[:4])
+        matches = [
+            index
+            for index, current in enumerate(group_bounds)
+            if x0 <= current[2] + gap_limit and x1 >= current[0] - gap_limit
+        ]
+        if not matches:
+            groups.append([word])
+            group_bounds.append([x0, y0, x1, y1])
+            continue
+        target = matches[0]
+        groups[target].append(word)
+        current = group_bounds[target]
+        current[:] = [
+            min(current[0], x0),
+            min(current[1], y0),
+            max(current[2], x1),
+            max(current[3], y1),
+        ]
+        for extra in reversed(matches[1:]):
+            groups[target].extend(groups.pop(extra))
+            other = group_bounds.pop(extra)
+            current[:] = [
+                min(current[0], other[0]),
+                min(current[1], other[1]),
+                max(current[2], other[2]),
+                max(current[3], other[3]),
+            ]
+
+    ordered = sorted(zip(groups, group_bounds), key=lambda item: item[1][0])
+    cx0, cy0, cx1, cy1 = bounds
+    result: list[TableTextCluster] = []
+    for index, (group, group_box) in enumerate(ordered):
+        left = cx0 if index == 0 else (ordered[index - 1][1][2] + group_box[0]) / 2
+        right = cx1 if index + 1 == len(ordered) else (
+            group_box[2] + ordered[index + 1][1][0]
+        ) / 2
+        text = " ".join(
+            str(word[4])
+            for word in sorted(
+                group,
+                key=lambda item: (
+                    int(item[5]) if len(item) > 5 else 0,
+                    int(item[6]) if len(item) > 6 else 0,
+                    int(item[7]) if len(item) > 7 else 0,
+                ),
+            )
+        )
+        result.append(
+            TableTextCluster(
+                (max(cx0, left), cy0, min(cx1, right), cy1),
+                text,
+                tuple(group),
+            )
+        )
+    return result
 
 
 def is_scanned_page(blocks: Iterable[Mapping[str, Any]], page_area: float) -> bool:

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -8,6 +8,7 @@ import logging
 import re
 import threading
 import unicodedata
+from collections import Counter
 from typing import Any, ClassVar
 
 import requests
@@ -17,6 +18,13 @@ from pdf2zh.cache import TranslationCache
 logger = logging.getLogger(__name__)
 
 PLACEHOLDER_PATTERN = re.compile(r"</?b\d+>")
+INTERNAL_PLACEHOLDER_PATTERN = re.compile(r"\{\s*v([\d\s]+)\}", re.IGNORECASE)
+PAIRED_PLACEHOLDER_PATTERN = re.compile(r"<b(\d+)></b\1>")
+STYLE_TAG_PATTERN = re.compile(r"<(/?)s([123])>", re.IGNORECASE)
+
+
+class FormulaPlaceholderError(ValueError):
+    """Raised when a translator damages or reorders protected formula tags."""
 
 
 def remove_control_characters(value: str) -> str:
@@ -132,6 +140,52 @@ def placeholders(text: str) -> list[str]:
     return PLACEHOLDER_PATTERN.findall(text)
 
 
+def encode_formula_placeholders(text: str) -> str:
+    """Turn converter-internal ``{vN}`` markers into translator-safe tag pairs."""
+    return INTERNAL_PLACEHOLDER_PATTERN.sub(
+        lambda match: f"<b{int(match.group(1).replace(' ', ''))}></b{int(match.group(1).replace(' ', ''))}>",
+        text,
+    )
+
+
+def restore_formula_placeholders(source: str, translated: str) -> str:
+    """Validate translator output and restore its tags to converter markers."""
+    encoded_source = encode_formula_placeholders(source)
+    if placeholders(encoded_source) != placeholders(translated):
+        raise FormulaPlaceholderError("formula placeholders changed during translation")
+    validate_style_tags(encoded_source, translated)
+    restored = PAIRED_PLACEHOLDER_PATTERN.sub(
+        lambda match: f"{{v{match.group(1)}}}", translated
+    )
+    if PLACEHOLDER_PATTERN.search(restored):
+        raise FormulaPlaceholderError("formula placeholder pair is malformed")
+    return restored
+
+
+def _style_tag_counts(text: str) -> Counter[str]:
+    """Return balanced style-pair counts, allowing complete pairs to reorder."""
+    stack: list[str] = []
+    pairs: Counter[str] = Counter()
+    for match in STYLE_TAG_PATTERN.finditer(text):
+        closing, identifier = match.groups()
+        if not closing:
+            stack.append(identifier)
+            continue
+        if not stack or stack[-1] != identifier:
+            raise FormulaPlaceholderError("style tags are malformed or cross-nested")
+        stack.pop()
+        pairs[identifier] += 1
+    if stack:
+        raise FormulaPlaceholderError("style tags are not closed")
+    return pairs
+
+
+def validate_style_tags(source: str, translated: str) -> None:
+    """Require the same balanced bold/italic runs after translation."""
+    if _style_tag_counts(source) != _style_tag_counts(translated):
+        raise FormulaPlaceholderError("style tags changed during translation")
+
+
 def load_segment_table(path: str | None) -> dict[str, str]:
     """Load a source-to-translation table from a JSONL file of {"src", "dst"} records.
 
@@ -157,9 +211,23 @@ def load_segment_table(path: str | None) -> dict[str, str]:
                 raise ValueError(f"{path} line {number}: 'src' and 'dst' must be strings")
             if not translation:
                 continue
+            # Old converter versions emitted {vN}; normalise those records so
+            # existing handoff files remain usable with the documented tags.
+            source = encode_formula_placeholders(source)
+            translation = encode_formula_placeholders(translation)
             if placeholders(source) != placeholders(translation):
                 logger.warning(
                     "%s line %d: formula placeholders differ between src and dst; "
+                    "segment left untranslated",
+                    path,
+                    number,
+                )
+                continue
+            try:
+                validate_style_tags(source, translation)
+            except FormulaPlaceholderError:
+                logger.warning(
+                    "%s line %d: style tags differ between src and dst; "
                     "segment left untranslated",
                     path,
                     number,

--- a/references/preservation-rules.md
+++ b/references/preservation-rules.md
@@ -6,7 +6,17 @@ The bundled core translates ordinary text while retaining document structures wh
 
 - Formula glyphs remain original PDF operators and are represented by placeholders only while surrounding prose is translated.
 - Formula detection covers TeX and common math fonts plus monospace/code families such as Consolas, Courier, Menlo, Monaco, Inconsolata, Source Code, Fira Code, DejaVu Sans Mono, and Liberation Mono.
-- Isolated formulas, formula captions, figures, and tables remain protected layout regions.
+- Ordinary-font blocks made only of mathematical operators and identifiers are protected, as are stacked numbered terms such as `F1/b0` inside prose.
+- Formula placeholders are validated after translation; a damaged or reordered placeholder leaves its segment untranslated instead of corrupting the PDF.
+- Isolated formulas, formula captions, and figures remain protected layout regions.
+
+## Tables
+
+- A layout-model table is translated cell by cell only when PyMuPDF can match a cell grid to at least half of the detected table region.
+- Visually merged cells are split into x-position clusters so natural-language labels can be translated without sending adjacent abbreviations, identifiers, numbers, or units to the translation service.
+- Each reliable cell is reflowed within its own bounds while the source grid, fills, and borders remain unchanged.
+- Cell translations may shrink to half the source font size. If text still cannot fit, that cell remains in the source language and the result is reported as partial.
+- Tables without a reliable cell grid remain fully protected.
 
 ## Numbered-page structures
 
@@ -23,6 +33,8 @@ These classifications preserve the complete page layout instead of reflowing num
 - Windows uses Times New Roman when available; other environments use the downloaded Unicode font fallback.
 - Long translations scale down before rendering, wrap at word boundaries, reduce line height when necessary, and shrink again only when the paragraph still exceeds its original box.
 - Extended bullets remain anchored, and vertically separated list items start new paragraphs.
+- Quarter-turn text keeps its source orientation. Rotated table headings are translated and fitted along their logical baseline instead of wrapping one glyph per line.
+- Bold, italic, and bold-italic runs travel through the translator as validated style markers and use the matching Times New Roman face on Windows. Missing variants use synthetic weight/slant without discarding the style.
 
 ## Scan and source safety
 
@@ -33,4 +45,4 @@ These classifications preserve the complete page layout instead of reflowing num
 
 ## Known limits
 
-Text inside a protected table or figure can remain in the source language. Complex embedded fonts, malformed content streams, or inaccurate layout-model classifications can also require manual review. Treat any substantial untranslated passage or visual defect as a partial result.
+Text inside an unmatched table or protected figure can remain in the source language. Complex embedded fonts, malformed content streams, or inaccurate layout-model classifications can also require manual review. Treat any substantial untranslated passage or visual defect as a partial result.

--- a/tests/test_handoff_translator.py
+++ b/tests/test_handoff_translator.py
@@ -6,7 +6,15 @@ import unittest
 from pathlib import Path
 
 from pdf2zh.cache import clean_test_db, init_test_db
-from pdf2zh.translator import HandoffTranslator, load_segment_table, placeholders
+from pdf2zh.translator import (
+    FormulaPlaceholderError,
+    HandoffTranslator,
+    encode_formula_placeholders,
+    load_segment_table,
+    placeholders,
+    restore_formula_placeholders,
+    validate_style_tags,
+)
 
 
 def _jsonl(path: Path, records: list[dict]) -> Path:
@@ -58,6 +66,55 @@ class SegmentTableTests(unittest.TestCase):
             placeholders("a <b0></b0> b <b1></b1>"),
             ["<b0>", "</b0>", "<b1>", "</b1>"],
         )
+
+    def test_legacy_converter_placeholders_are_normalised(self):
+        path = _jsonl(
+            self.root / "table.jsonl",
+            [{"src": "where {v0} holds", "dst": "nÆ¡i {v0} Ä‘Ãºng"}],
+        )
+        self.assertEqual(
+            load_segment_table(str(path)),
+            {"where <b0></b0> holds": "nÆ¡i <b0></b0> Ä‘Ãºng"},
+        )
+
+    def test_converter_placeholders_round_trip_through_safe_tags(self):
+        source = "{v27} C{v28}[ ]"
+        encoded = encode_formula_placeholders(source)
+        self.assertEqual(encoded, "<b27></b27> C<b28></b28>[ ]")
+        self.assertEqual(restore_formula_placeholders(source, encoded), source)
+
+    def test_damaged_or_reordered_placeholder_tags_are_rejected(self):
+        source = "{v0} and {v1}"
+        for translated in (
+            "<b0></b0> and <b1>",
+            "<b1></b1> and <b0></b0>",
+        ):
+            with self.subTest(translated=translated):
+                with self.assertRaises(FormulaPlaceholderError):
+                    restore_formula_placeholders(source, translated)
+
+    def test_balanced_style_pairs_may_reorder_as_complete_runs(self):
+        validate_style_tags(
+            "<s1>Bold</s1> and <s2>italic</s2>",
+            "<s2>nghiêng</s2> và <s1>đậm</s1>",
+        )
+
+    def test_missing_or_cross_nested_style_tags_are_rejected(self):
+        source = "<s1>Bold</s1> and <s2>italic</s2>"
+        for translated in (
+            "đậm and <s2>nghiêng</s2>",
+            "<s1><s2>sai</s1></s2>",
+        ):
+            with self.subTest(translated=translated):
+                with self.assertRaises(FormulaPlaceholderError):
+                    validate_style_tags(source, translated)
+
+    def test_handoff_skips_a_translation_that_loses_style(self):
+        path = _jsonl(
+            self.root / "table.jsonl",
+            [{"src": "<s1>Important</s1>", "dst": "Quan trọng"}],
+        )
+        self.assertEqual(load_segment_table(str(path)), {})
 
 
 class HandoffTranslatorTests(unittest.TestCase):

--- a/tests/test_inline_formula_layout.py
+++ b/tests/test_inline_formula_layout.py
@@ -9,8 +9,23 @@ because every line in a paragraph got the same leading.
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 
-from pdf2zh.converter import line_offsets
+from pdf2zh.converter import (
+    IDENTITY_ORIENTATION,
+    TextStyle,
+    line_offsets,
+    matrix_font_size,
+    preferred_translation,
+    should_translate_rotated_text,
+    styled_text_matrix,
+    styled_character_text,
+    text_fits_box_at_minimum_size,
+    text_orientation,
+    text_style_from_font,
+    uses_synthetic_bold,
+)
+from pdf2zh.high_level import output_style_font_paths
 from pdf2zh.pdfinterp import PDFPageInterpreterEx
 from pdfminer.pdfinterp import PDFGraphicState, PDFResourceManager
 
@@ -130,8 +145,91 @@ class LineOffsetTests(unittest.TestCase):
     def test_a_single_line_paragraph_needs_no_gaps(self):
         self.assertEqual(self._offsets({0: (-2.2, 7.8)}, 0), [0.0])
 
+    def test_negative_cell_slack_with_no_formula_extra_keeps_plain_leading(self):
+        prose = (-2.2, 7.8)
+        self.assertEqual(
+            [round(o, 4) for o in self._offsets({0: prose, 1: prose}, 1, budget=-1.0)],
+            [0.0, 11.0],
+        )
+
     def test_lines_without_recorded_ink_fall_back_to_the_usual_leading(self):
         self.assertEqual([round(o, 4) for o in self._offsets({}, 2)], [0.0, 11.0, 22.0])
+
+
+class TableCellFitTests(unittest.TestCase):
+    @staticmethod
+    def _measure(_character, size):
+        return size
+
+    def test_short_translation_fits_at_half_size(self):
+        self.assertTrue(
+            text_fits_box_at_minimum_size("two words", 25, 10, 10, [], self._measure)
+        )
+
+    def test_translation_that_needs_too_many_lines_falls_back(self):
+        self.assertFalse(
+            text_fits_box_at_minimum_size(
+                "one two three four", 15, 5, 10, [], self._measure
+            )
+        )
+
+    def test_formula_placeholder_uses_its_original_width(self):
+        self.assertFalse(
+            text_fits_box_at_minimum_size("{v0}", 10, 10, 10, [20], self._measure)
+        )
+
+
+class OrientationAndStyleTests(unittest.TestCase):
+    def test_quarter_turn_matrices_are_classified(self):
+        self.assertEqual(text_orientation((8, 0, 0, 8, 0, 0)), IDENTITY_ORIENTATION)
+        self.assertEqual(text_orientation((0, 8, -8, 0, 0, 0)), (0, 1, -1, 0))
+        self.assertEqual(text_orientation((-8, 0, 0, -8, 0, 0)), (-1, 0, 0, -1))
+        self.assertEqual(text_orientation((0, -8, 8, 0, 0, 0)), (0, -1, 1, 0))
+        self.assertIsNone(text_orientation((6, 4, -4, 6, 0, 0)))
+
+    def test_rotated_font_size_comes_from_matrix_not_glyph_advance(self):
+        self.assertEqual(matrix_font_size((0, 8, -8, 0, 0, 0)), 8)
+
+    def test_font_face_names_map_to_inline_styles(self):
+        cases = {
+            "MyriadPro-Regular": TextStyle.REGULAR,
+            "MyriadPro-Semibold": TextStyle.BOLD,
+            "TimesNewRomanPS-ItalicMT": TextStyle.ITALIC,
+            "TimesNewRomanPS-BoldItalicMT": TextStyle.BOLD_ITALIC,
+        }
+        for face, expected in cases.items():
+            with self.subTest(face=face):
+                self.assertEqual(text_style_from_font(face), expected)
+
+    def test_styled_runs_are_serialised_without_losing_text(self):
+        chars = [
+            SimpleNamespace(fontname="Regular", get_text=lambda: "A"),
+            SimpleNamespace(fontname="SemiBold", get_text=lambda: "B"),
+            SimpleNamespace(fontname="Italic", get_text=lambda: "C"),
+        ]
+        self.assertEqual(styled_character_text(chars), "A<s1>B</s1><s2>C</s2>")
+
+    def test_rotated_vietnamese_headers_have_stable_terminology_and_style(self):
+        self.assertEqual(
+            preferred_translation("<s1>Designation</s1>", "vi"),
+            "<s1>Tên gọi</s1>",
+        )
+        self.assertEqual(preferred_translation("Unit", "vi"), "Đơn vị")
+        self.assertIsNone(preferred_translation("Designation", "fr"))
+        self.assertFalse(should_translate_rotated_text("Ref. no. 304-2"))
+        self.assertTrue(should_translate_rotated_text("Designation"))
+
+    def test_synthetic_italic_composes_with_rotation(self):
+        self.assertEqual(
+            styled_text_matrix((0, 1, -1, 0), TextStyle.ITALIC, True),
+            (0, 1, -1.0, 0.2),
+        )
+        self.assertTrue(uses_synthetic_bold(TextStyle.BOLD_ITALIC, True))
+        self.assertFalse(uses_synthetic_bold(TextStyle.BOLD, False))
+
+    def test_missing_style_faces_fall_back_to_the_regular_font(self):
+        paths = output_style_font_paths("vi", "C:/missing/regular.ttf")
+        self.assertEqual(set(paths.values()), {"C:\\missing\\regular.ttf"})
 
 
 if __name__ == "__main__":

--- a/tests/test_preservation_rules.py
+++ b/tests/test_preservation_rules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 
 from pdfminer.pdfinterp import PDFResourceManager
 
@@ -8,9 +9,13 @@ from pdf2zh.converter import TranslateConverter
 from pdf2zh.rules import (
     BULLET_CHARACTERS,
     classify_preserved_page,
+    cluster_table_words,
+    formula_regions,
     is_formula_font,
     is_scanned_page,
     line_height_for_language,
+    matching_table_cells,
+    should_translate_table_cell,
 )
 
 
@@ -27,6 +32,79 @@ class PreservationRuleTests(unittest.TestCase):
             with self.subTest(font=font):
                 self.assertTrue(is_formula_font(font))
         self.assertFalse(is_formula_font("TimesNewRomanPSMT"))
+
+    def test_operator_only_ordinary_font_block_is_protected_as_formula(self):
+        blocks = [(10, 20, 90, 40, "F1 / b0 â‰¤ C2 [N/mm]")]
+        self.assertEqual(formula_regions(blocks, []), [(10.0, 20.0, 90.0, 40.0)])
+
+    def test_prose_containing_variables_is_not_protected_as_a_formula(self):
+        blocks = [(10, 20, 190, 40, "If F1 is larger than C2, use another belt")]
+        self.assertEqual(formula_regions(blocks, []), [])
+
+    def test_stacked_numbered_identifiers_are_protected_inside_prose(self):
+        words = [
+            (10, 10, 20, 20, "F1", 7, 0, 0),
+            (10, 20, 20, 30, "b0", 7, 1, 0),
+            (30, 20, 60, 30, "value", 7, 1, 1),
+        ]
+        self.assertEqual(formula_regions([], words), [(10.0, 10.0, 20.0, 30.0)])
+
+    def test_stacked_detection_does_not_cross_a_protected_table(self):
+        words = [
+            (10, 10, 20, 20, "F1", 7, 0, 0),
+            (10, 20, 20, 30, "F2", 7, 1, 0),
+        ]
+        self.assertEqual(
+            formula_regions([], words, stacked_exclusions=[(0, 0, 100, 100)]),
+            [],
+        )
+
+    def test_table_cells_require_a_half_area_model_match(self):
+        matching = SimpleNamespace(
+            bbox=(0, 0, 100, 140),
+            cells=[(0, 0, 50, 50), (50, 0, 100, 50), (0, 100, 100, 140)],
+        )
+        distant = SimpleNamespace(bbox=(200, 200, 300, 300), cells=[(200, 200, 300, 300)])
+        self.assertEqual(
+            matching_table_cells((0, 0, 100, 100), [distant, matching]),
+            [(0.0, 0.0, 50.0, 50.0), (50.0, 0.0, 100.0, 50.0)],
+        )
+        self.assertEqual(
+            matching_table_cells((0, 0, 100, 100), [SimpleNamespace(bbox=(0, 0, 40, 100), cells=[])]),
+            [],
+        )
+
+    def test_table_codes_and_numbers_stay_as_original_glyphs(self):
+        for value in ("E 2/1, E 3/1, NOVO", "180Â° 210Â° 240Â°", "2.0"):
+            with self.subTest(value=value):
+                self.assertFalse(should_translate_table_cell(value))
+        self.assertTrue(should_translate_table_cell("Tension member"))
+        self.assertTrue(should_translate_table_cell("Lá»›p phá»§ máº·t dÆ°á»›i"))
+
+    def test_merged_description_and_code_cell_splits_into_x_clusters(self):
+        words = [
+            (0, 0, 20, 10, "Drive", 1, 0, 0),
+            (22, 0, 45, 10, "drum", 1, 0, 1),
+            (47, 0, 80, 10, "diameter", 1, 0, 2),
+            (160, 0, 170, 10, "dA", 1, 0, 3),
+        ]
+        clusters = cluster_table_words(words, (0, 0, 180, 12))
+        self.assertEqual([cluster.text for cluster in clusters], ["Drive drum diameter", "dA"])
+        self.assertTrue(should_translate_table_cell(clusters[0].text))
+        self.assertFalse(should_translate_table_cell(clusters[1].text))
+
+    def test_wrapped_description_lines_stay_in_one_cluster(self):
+        words = [
+            (0, 0, 30, 10, "Maximum", 1, 0, 0),
+            (32, 0, 50, 10, "belt", 1, 0, 1),
+            (0, 11, 20, 21, "pull", 1, 1, 0),
+            (22, 11, 55, 21, "allowed", 1, 1, 1),
+            (160, 5, 170, 15, "F1", 1, 2, 0),
+        ]
+        clusters = cluster_table_words(words, (0, 0, 180, 24))
+        self.assertEqual(len(clusters), 2)
+        self.assertIn("Maximum", clusters[0].text)
+        self.assertIn("allowed", clusters[0].text)
 
     def test_vietnamese_line_height_and_extended_bullets_are_preserved(self):
         self.assertEqual(line_height_for_language("vi"), 1.2)
@@ -93,6 +171,15 @@ class PreservationRuleTests(unittest.TestCase):
             with self.subTest(service=service):
                 converter = TranslateConverter(PDFResourceManager(), service=service)
                 self.assertEqual(converter.translator.name, service)
+
+    def test_converter_keeps_the_late_filled_cell_bounds_mapping(self):
+        bounds = {}
+        converter = TranslateConverter(
+            PDFResourceManager(), service="google", layout_bounds=bounds
+        )
+        bounds[0] = {7: (1, 2, 3, 4)}
+        self.assertIs(converter.layout_bounds, bounds)
+        self.assertEqual(converter.layout_bounds[0][7], (1, 2, 3, 4))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- preserve ordinary-font formulas, inline fractions, and safe placeholders
- translate reliable table cells while protecting identifiers, numbers, and units
- preserve 90-degree text orientation plus bold, italic, and bold-italic runs
- prevent translated text from overflowing adjacent rows or columns
- bump the desktop app version to 0.2.1

## Validation

- 93/93 unit tests passed
- `pip check` passed
- hard-error Ruff checks passed
- translated and visually reviewed all 16 pages of the conveyor-belt sample
- Windows package build and payload validation passed

The Windows release remains unsigned.