### PR TITLE
Add macOS Apple Silicon desktop build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,30 @@ jobs:
         with:
           files: dist/PDFTranslate-windows.zip
           generate_release_notes: true
+
+  macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check the tag matches APP_VERSION
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(sed -n 's/^APP_VERSION = "\([^"]*\)"$/\1/p' app/update.py)"
+          test "$tag" = "$version"
+
+      - name: Create the virtual environment
+        run: python -m venv .venv
+
+      - name: Build
+        run: ./build-macos.sh
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/PDFTranslate-macos.zip
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
   <a href="https://github.com/breslee1707/VI-Translate/releases/latest/download/PDFTranslate-windows.zip">
     <img src="https://img.shields.io/badge/TẢI_XUỐNG-Windows_x64-1f6feb?style=for-the-badge&logo=windows11&logoColor=white" alt="Tải PDF Translate cho Windows">
   </a>
+  <a href="https://github.com/breslee1707/VI-Translate/releases/latest/download/PDFTranslate-macos.zip">
+    <img src="https://img.shields.io/badge/TẢI_XUỐNG-macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Tải PDF Translate cho macOS">
+  </a>
 </p>
 
 <p align="center">
@@ -31,7 +34,7 @@
 
 ---
 
-PDF Translate là ứng dụng desktop mã nguồn mở dành cho Windows. Công cụ phân tích bố cục từng trang, bảo vệ công thức và code, dịch phần văn xuôi rồi đặt nội dung trở lại đúng vị trí trong tài liệu gốc — không biến PDF của bạn thành một trang chữ trắng đơn giản.
+PDF Translate là ứng dụng desktop mã nguồn mở dành cho Windows và macOS. Công cụ phân tích bố cục từng trang, bảo vệ công thức và code, dịch phần văn xuôi rồi đặt nội dung trở lại đúng vị trí trong tài liệu gốc — không biến PDF của bạn thành một trang chữ trắng đơn giản.
 
 ## Điểm nổi bật
 
@@ -45,12 +48,12 @@ PDF Translate là ứng dụng desktop mã nguồn mở dành cho Windows. Công
 
 ## Bắt đầu trong 1 phút
 
-1. **[Tải PDF Translate cho Windows](https://github.com/breslee1707/VI-Translate/releases/latest/download/PDFTranslate-windows.zip)** (`.zip`, khoảng 199 MB).
+1. Tải PDF Translate cho **[Windows](https://github.com/breslee1707/VI-Translate/releases/latest/download/PDFTranslate-windows.zip)** hoặc **[macOS Apple Silicon](https://github.com/breslee1707/VI-Translate/releases/latest/download/PDFTranslate-macos.zip)**.
 2. Giải nén toàn bộ file vừa tải.
-3. Mở `PDFTranslate.exe`.
+3. Mở `PDFTranslate.exe` trên Windows hoặc `PDFTranslate.app` trên macOS.
 
 > [!NOTE]
-> Ứng dụng hiện chỉ hỗ trợ **Windows 64-bit**. Bản desktop không cần cài Python và không phải tải thêm model ở lần chạy đầu. Quá trình dịch bằng Google vẫn cần kết nối Internet.
+> Ứng dụng hỗ trợ **Windows 64-bit** và **macOS Apple Silicon**. Bản desktop không cần cài Python và không phải tải thêm model ở lần chạy đầu. Quá trình dịch bằng Google vẫn cần kết nối Internet.
 
 > [!WARNING]
 > Windows SmartScreen có thể cảnh báo vì ứng dụng chưa được ký số. Chọn **More info** → **Run anyway** nếu bạn tải file từ trang Releases chính thức của repo này.
@@ -169,6 +172,17 @@ python -m venv .venv
 ```
 
 Gói phát hành được tạo tại `dist\PDFTranslate-windows.zip`.
+
+### Build ứng dụng macOS
+
+Python dùng để tạo môi trường cần có Tk/Tcl.
+
+```bash
+python3 -m venv .venv
+./build-macos.sh
+```
+
+Gói phát hành được tạo tại `dist/PDFTranslate-macos.zip`. PyInstaller không cross-compile, vì vậy mỗi gói phải được build trên đúng hệ điều hành.
 
 ## Giới hạn hiện tại
 

--- a/app.spec
+++ b/app.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-"""PyInstaller spec for the Windows desktop app.
+"""PyInstaller spec for the Windows and macOS desktop apps.
 
 One-folder, deliberately not --onefile: onnxruntime, opencv, and PyMuPDF push
 the bundle past 400 MB, and onefile re-extracts all of that to a temp directory
@@ -7,6 +7,7 @@ on every launch, which is slow and trips antivirus heuristics.
 """
 
 from pathlib import Path
+import sys
 
 from PyInstaller.utils.hooks import collect_data_files
 
@@ -71,7 +72,7 @@ exe = EXE(
     [],
     exclude_binaries=True,
     name="PDFTranslate",
-    icon=str(ROOT / "app" / "assets" / "icon.ico"),
+    icon=str(ROOT / "app" / "assets" / ("icon.png" if sys.platform == "darwin" else "icon.ico")),
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -93,3 +94,15 @@ collect = COLLECT(
     upx_exclude=[],
     name="PDFTranslate",
 )
+
+if sys.platform == "darwin":
+    app = BUNDLE(
+        collect,
+        name="PDFTranslate.app",
+        icon=str(ROOT / "app" / "assets" / "icon.png"),
+        bundle_identifier="io.github.breslee1707.pdftranslate",
+        info_plist={
+            "CFBundleDisplayName": "PDF Translate",
+            "NSHighResolutionCapable": True,
+        },
+    )

--- a/app/gui.py
+++ b/app/gui.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import ctypes
 import os
 import queue
+import subprocess
 import sys
 import threading
 import tkinter
@@ -39,8 +40,8 @@ FONT_DIRECTORY = APP_ROOT / "app" / "fonts"
 ASSET_DIRECTORY = APP_ROOT / "app" / "assets"
 UI_FONT = "Be Vietnam Pro"
 MONO_FONT = "JetBrains Mono"
-FALLBACK_UI_FONT = "Segoe UI"
-FALLBACK_MONO_FONT = "Consolas"
+FALLBACK_UI_FONT = "Helvetica" if sys.platform == "darwin" else "Segoe UI"
+FALLBACK_MONO_FONT = "Menlo" if sys.platform == "darwin" else "Consolas"
 
 # One 8px rhythm for the whole window, so nothing is spaced by feel.
 PAD, GAP, EDGE = 8, 16, 24
@@ -143,7 +144,10 @@ def collect_pdfs(paths: list[Path]) -> list[Path]:
     for path in paths:
         if path.is_dir():
             # Not glob("*.pdf"): that is case-sensitive on POSIX and would miss .PDF.
-            found.extend(sorted(p for p in path.iterdir() if _is_pdf(p)))
+            found.extend(sorted(
+                (p for p in path.iterdir() if _is_pdf(p)),
+                key=lambda item: item.name.casefold(),
+            ))
         elif path.suffix.lower() == ".pdf":
             found.append(path)
     unique: dict[Path, None] = {}
@@ -214,7 +218,14 @@ class QueueRow:
 class App(ctk.CTk, TkinterDnD.DnDWrapper):
     def __init__(self) -> None:
         super().__init__()
-        self.TkdndVersion = TkinterDnD._require(self)
+        try:
+            self.TkdndVersion = TkinterDnD._require(self)
+        except RuntimeError:
+            # tkdnd currently targets Tk 8.6 on macOS. Homebrew may pair
+            # Python with Tk 9, where file pickers still work but loading the
+            # older native extension fails. Drag and drop is optional, so do
+            # not make that prevent the whole application from starting.
+            self.TkdndVersion = None
 
         has_fonts = load_bundled_fonts()
         self.ui_font = UI_FONT if has_fonts else FALLBACK_UI_FONT
@@ -237,10 +248,11 @@ class App(ctk.CTk, TkinterDnD.DnDWrapper):
         self.outputs: dict[Path, Path] = {}
 
         self._build()
-        self.drop_target_register(DND_FILES)
-        self.dnd_bind("<<Drop>>", self._on_drop)
-        self.dnd_bind("<<DropEnter>>", self._on_drag_enter)
-        self.dnd_bind("<<DropLeave>>", self._on_drag_leave)
+        if self.TkdndVersion is not None:
+            self.drop_target_register(DND_FILES)
+            self.dnd_bind("<<Drop>>", self._on_drop)
+            self.dnd_bind("<<DropEnter>>", self._on_drag_enter)
+            self.dnd_bind("<<DropLeave>>", self._on_drag_leave)
         self.after(100, self._drain_events)
         # Both background threads are staggered: each one holds the GIL long
         # enough while importing to make the freshly opened window hitch, and
@@ -464,8 +476,13 @@ class App(ctk.CTk, TkinterDnD.DnDWrapper):
         if target is None or not Path(target).exists():
             return
         try:
-            os.startfile(target)  # noqa: S606 - Windows shell open, the app is Windows only
-        except OSError:
+            if sys.platform == "win32":
+                os.startfile(target)  # type: ignore[attr-defined]  # noqa: S606
+            elif sys.platform == "darwin":
+                subprocess.run(["open", str(target)], check=False)  # noqa: S603,S607
+            else:
+                subprocess.run(["xdg-open", str(target)], check=False)  # noqa: S603,S607
+        except (OSError, subprocess.SubprocessError):
             pass  # nothing useful to do if the shell refuses
 
     def _show_output_link(self) -> None:

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+python="$root/.venv/bin/python"
+app="$root/dist/PDFTranslate.app"
+archive="$root/dist/PDFTranslate-macos.zip"
+
+if [[ ! -x "$python" ]]; then
+    echo "No virtual environment found. Run: python3 -m venv .venv" >&2
+    exit 1
+fi
+
+echo "==> Installing app and packaging dependencies"
+"$python" -m pip install -r "$root/requirements-app.txt"
+
+if [[ "${1:-}" != "--skip-assets" ]]; then
+    echo "==> Fetching the layout model and font to bundle"
+    "$python" "$root/scripts/fetch_assets.py"
+fi
+
+echo "==> Running PyInstaller"
+"$python" -m PyInstaller --noconfirm --clean "$root/app.spec"
+
+required=(
+    "$app/Contents/MacOS/PDFTranslate"
+    "$app/Contents/Info.plist"
+    "$app/Contents/Resources/app/fonts/BeVietnamPro-Regular.ttf"
+    "$app/Contents/Resources/app/assets/icon.png"
+)
+for path in "${required[@]}"; do
+    if [[ ! -e "$path" ]]; then
+        echo "Incomplete build, missing: $path" >&2
+        exit 1
+    fi
+done
+
+echo "==> Creating $archive"
+rm -f "$archive"
+ditto -c -k --sequesterRsrc --keepParent "$app" "$archive"
+echo "==> Done"

--- a/tests/test_app_gui.py
+++ b/tests/test_app_gui.py
@@ -5,9 +5,10 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 try:
-    from app.gui import LANGUAGE_NAMES, collect_pdfs, ensure_writable_streams
+    from app.gui import App, LANGUAGE_NAMES, collect_pdfs, ensure_writable_streams
 except ImportError:  # customtkinter and tkinterdnd2 are app-only dependencies
     collect_pdfs = None
 
@@ -87,6 +88,17 @@ class WritableStreamTests(unittest.TestCase):
         sys.stdout = marker
         ensure_writable_streams()
         self.assertIs(sys.stdout, marker)
+
+
+@unittest.skipIf(collect_pdfs is None, "desktop app dependencies are not installed")
+class OpenOutputTests(unittest.TestCase):
+    def test_macos_opens_the_output_with_the_system_open_command(self):
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch("app.gui.sys.platform", "darwin"), \
+                mock.patch("app.gui.subprocess.run") as run:
+            target = Path(directory)
+            App._open(target)
+        run.assert_called_once_with(["open", str(target)], check=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_inline_formula_layout.py
+++ b/tests/test_inline_formula_layout.py
@@ -9,6 +9,7 @@ because every line in a paragraph got the same leading.
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from pdf2zh.converter import (
@@ -229,7 +230,7 @@ class OrientationAndStyleTests(unittest.TestCase):
 
     def test_missing_style_faces_fall_back_to_the_regular_font(self):
         paths = output_style_font_paths("vi", "C:/missing/regular.ttf")
-        self.assertEqual(set(paths.values()), {"C:\\missing\\regular.ttf"})
+        self.assertEqual(set(paths.values()), {str(Path("C:/missing/regular.ttf"))})
 
 
 if __name__ == "__main__":

--- a/tests/test_translate_pdf.py
+++ b/tests/test_translate_pdf.py
@@ -12,7 +12,9 @@ from scripts import translate_pdf
 class TranslatePdfTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_directory = tempfile.TemporaryDirectory()
-        self.root = Path(self.temp_directory.name)
+        # macOS exposes /var as a symlink to /private/var. Match production,
+        # which resolves paths before returning them.
+        self.root = Path(self.temp_directory.name).resolve()
         self.source = self.root / "guide.pdf"
         self.source.write_bytes(b"%PDF-1.7\nsource")
         self.output = self.root / "output"


### PR DESCRIPTION
## Summary

- make the desktop GUI open output paths and choose fallback fonts on macOS
- package an Apple Silicon `PDFTranslate.app` and release zip with PyInstaller
- add a macOS release job alongside the existing Windows job
- keep the app usable when Tk 9 cannot load the Tk 8.6 `tkdnd` extension (file pickers remain available)
- update documentation and make path/order tests portable across Windows and macOS

## Verification

- `.venv/bin/python -m unittest discover -s tests` — 94 tests passed
- `./build-macos.sh` — produced a 392 MB app / 192 MB zip on macOS 26.6.2 arm64
- `codesign --verify --deep --strict dist/PDFTranslate.app`
- extracted `PDFTranslate-macos.zip` and verified its executable
- launched the bundled executable and confirmed the GUI remained running; the layout model initialized through ONNX Runtime/CoreML

The existing Windows build path remains unchanged; PyInstaller selects the platform-specific icon and only creates `BUNDLE` on Darwin.