### PR TITLE
Share repository knowledge across Codex and Claude

### DIFF
--- a/.claude/skills/pdf-translate/SKILL.md
+++ b/.claude/skills/pdf-translate/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: pdf-translate
+description: Translate or diagnose local text-based PDFs in this repository while preserving layout, formulas, tables, figures, styles, rotation, and technical glyphs. Use for PDF translation, incomplete output, visual regressions, or preservation fixes; not for OCR-only scans or complex-script targets.
+---
+
+# PDF Translate Project Skill
+
+This is the Claude Code adapter for the canonical cross-agent skill.
+
+Before acting:
+
+1. Read `../../../SKILL.md` completely and follow its workflow and boundaries.
+2. Read `../../../agent-knowledge/index.md`, then its routed PDF engine,
+   regression, and validation files relevant to the request.
+3. Resolve commands from the repository root containing `pdf2zh/` and
+   `scripts/translate_pdf.py`, not from this adapter directory.
+
+On macOS use `.venv/bin/python` and `bash build-macos.sh`; on Windows use
+`.venv\Scripts\python.exe` and `build.ps1`. The preservation behavior and tests
+are shared across platforms. Keep the source unchanged, validate rendered
+output, and report partial fallbacks honestly.

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,7 @@ pdf-translate.log
 Thumbs.db
 desktop.ini
 
-# Local contributor instructions; keep them out of the repository.
-/AGENTS.md
+# Personal agent overrides stay local. Shared Codex/Claude instructions are
+# tracked in AGENTS.md, CLAUDE.md, .claude/skills/, and agent-knowledge/.
+/CLAUDE.local.md
+/.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Shared Knowledge
+
+The canonical instructions for Codex and Claude live in
+[`agent-knowledge/index.md`](agent-knowledge/index.md). Read that file before
+acting, then load the topic files it routes to for the current task. Do not copy
+those details into this file; update the shared knowledge when behavior changes.
+
+## Working Contract
+
+- Preserve source PDFs and unrelated user changes. Generated PDFs, models,
+  caches, virtual environments, `build/`, and `dist/` are not source artifacts.
+- Keep preservation-sensitive changes in `pdf2zh/` small and backed by a
+  regression test that demonstrates the failing geometry, marker, or glyph.
+- Use Python 3.12 and the repository virtual environment. Run the full
+  `unittest` suite, `pip check`, hard-error Ruff checks, and proportionate PDF
+  render QA before handoff.
+- Do not commit, push, merge, tag, publish, sign, or overwrite user output
+  unless the user has authorized that operation. A release must have matching
+  `APP_VERSION` and `v*` tag values.
+- Keep UI text consistent with the existing Vietnamese application. Follow
+  nearby Python style: four spaces, type annotations, `snake_case` functions,
+  `PascalCase` classes, `UPPER_CASE` constants, and `pathlib.Path` for paths.
+
+## Task Routing
+
+- Repository layout and commands: [`repository.md`](agent-knowledge/repository.md)
+- PDF architecture and invariants: [`pdf-engine.md`](agent-knowledge/pdf-engine.md)
+- Known failures and proven fixes: [`regressions.md`](agent-knowledge/regressions.md)
+- Test and visual QA: [`validation.md`](agent-knowledge/validation.md)
+- Windows/macOS builds and releases: [`release.md`](agent-knowledge/release.md)
+
+The reusable translation workflow remains in [`SKILL.md`](SKILL.md). Claude
+Code uses the project adapter under `.claude/skills/pdf-translate/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+@agent-knowledge/index.md
+
+## Claude Code Adapter
+
+- Treat `agent-knowledge/` as the shared source of truth with Codex. Read the
+  topic file routed by the index before changing code or release state.
+- Use the project skill `/pdf-translate` for PDF translation, preservation
+  diagnosis, regression QA, or incomplete-output investigation.
+- On macOS, start Claude Code from this repository (or a subdirectory). Claude
+  automatically discovers `.claude/skills/pdf-translate/SKILL.md` after a
+  clone or pull. If `.claude/skills` was created after the current session
+  started, restart Claude once, then verify discovery with `/skills`.
+- Keep personal machine paths, permissions, and secrets in
+  `CLAUDE.local.md` or `.claude/settings.local.json`; both are gitignored.

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,6 +8,12 @@ license: AGPL-3.0-only
 
 Translate a PDF with the bundled Code4Life engine. Keep the source file unchanged and produce a separate PDF with the same page structure.
 
+When this skill runs inside the repository, first read
+[`agent-knowledge/index.md`](agent-knowledge/index.md). For preservation or
+layout work, load its PDF engine, regression, and validation routes. These are
+the shared project instructions for Codex and Claude; do not duplicate them in
+this entrypoint.
+
 ## Resolve the skill root
 
 This skill may be installed globally while the user's files live elsewhere. Resolve the absolute directory containing this `SKILL.md` before running anything. Call its scripts and dependency files by absolute path; do not assume the current working directory is the skill directory.

--- a/agent-knowledge/index.md
+++ b/agent-knowledge/index.md
@@ -1,0 +1,32 @@
+# Shared Agent Knowledge
+
+This directory is the maintained project memory for both Codex and Claude.
+Entry files should stay short; detailed, decision-changing knowledge belongs
+here and must be updated with the code that changes it.
+
+## Always Apply
+
+- The source PDF is immutable. Write translations to a separate output path.
+- Prefer a partial but structurally valid translation over damaged formulas,
+  missing markers, broken tables, lost styles, or clipped text.
+- Use the bundled `pdf2zh/` core and supported CLI. Do not silently substitute
+  the PyPI package or add OCR/complex-script support that the engine lacks.
+- Generated PDFs, models, optimized graphs, caches, build folders, virtual
+  environments, and release archives stay out of commits.
+- Diagnose with evidence from the actual PDF: matrices, font resources,
+  content streams, page geometry, extracted spans, and rendered pages.
+- External mutations such as overwrite, push, merge, tag, release, signing,
+  or deletion require scope from the user. Verify exact targets first.
+
+## Load by Task
+
+| Task | Read |
+| --- | --- |
+| Navigate or modify the repository | [repository.md](repository.md) |
+| Change translation/layout behavior | [pdf-engine.md](pdf-engine.md) and [regressions.md](regressions.md) |
+| Diagnose or deliver a PDF | [validation.md](validation.md) and the relevant regression entries |
+| Build, merge, or publish | [release.md](release.md) and [validation.md](validation.md) |
+
+For PDF work, also read the product contract in
+[`references/preservation-rules.md`](../references/preservation-rules.md) and
+the reusable workflow in [`SKILL.md`](../SKILL.md).

--- a/agent-knowledge/pdf-engine.md
+++ b/agent-knowledge/pdf-engine.md
@@ -1,0 +1,45 @@
+# PDF Engine Architecture and Invariants
+
+## Pipeline
+
+1. `scripts/translate_pdf.py` validates a text-based PDF and stages output.
+2. `pdf2zh/high_level.py` loads fonts/model, predicts layout, matches tables,
+   detects preserved structures, patches pages, and serializes the mono PDF.
+3. `pdf2zh/converter.py` groups glyphs into paragraphs, carries formulas and
+   styles through translation markers, reflows text, and emits PDF operators.
+4. `pdf2zh/translator.py` validates placeholders/style markers and caches only
+   safe translations.
+5. `pdf2zh/pdfinterp.py` retains source graphics while replacing selected text.
+
+## Preservation Invariants
+
+- Formula glyphs and rules retain source fonts and relative geometry. Ordinary
+  fonts can still contain formulas, so detection also uses operators and
+  stacked-token geometry.
+- `{vN}` is the internal formula placeholder. Translators receive safe
+  `<bN></bN>` tags. Missing or reordered formula tags reject the translation.
+- `<s1>`, `<s2>`, and `<s3>` carry bold, italic, and bold-italic runs. Pairs may
+  move with their phrase but must stay balanced and non-cross-nested.
+- Tables translate per reliable cell only when the model region and
+  `PyMuPDF.find_tables()` overlap by at least 50%. Grid, fill, and border
+  operators remain source content. Unreliable tables stay protected.
+- Quarter-turn text uses logical baseline orientation. Reflected matrices used
+  with negative font sizes are normalized before classification.
+- Symbol/Wingdings private-use bullets remain source glyphs in their embedded
+  dingbat font; prose fonts must not receive those code points.
+- Text fitting accounts for first-line indentation, final glyph ink, formula
+  offsets, and cell borders. The minimum translated size is 50% of source;
+  unsafe overflow falls back to source text and records a partial result.
+- Scanned image-only pages are not OCRed. Source pixels under translated text
+  receive backing only where required by the scan path.
+
+## Large Documents
+
+The app requests mono output only; do not construct the unused interleaved
+dual-language document. A PDF is large at 200 pages or 50 MiB. Large PDFs skip
+whole-document font subsetting and use light serialization
+(`garbage=1`, no recompression/object streams) because aggressive cleanup can
+hold the GIL for tens of seconds after page progress reaches 100%.
+
+The product-level authority is
+[`references/preservation-rules.md`](../references/preservation-rules.md).

--- a/agent-knowledge/regressions.md
+++ b/agent-knowledge/regressions.md
@@ -1,0 +1,19 @@
+# Proven Regression Patterns
+
+Use this as a cause map, not a substitute for inspecting the failing PDF.
+
+| Symptom | Proven cause | Guard / regression location |
+| --- | --- | --- |
+| GUI stops at the last page on a large book | Unused dual PDF doubled pages; font subsetting and `garbage=3` recompressed the whole document while holding the GIL | Mono-only app path and large-document thresholds in `high_level.py`; `test_large_document_finalization.py` |
+| Whole page appears upside down | A visually upright source used a reflected `1 0 0 -1` text matrix with negative font size; reflection was mistaken for rotation | Classify from baseline and normalize reflection; orientation tests |
+| Rotated heading becomes one glyph per line | Source 90-degree baseline was rebuilt as horizontal text | Quarter-turn grouping/rendering in `converter.py`; orientation/style tests |
+| Bold or italic disappears | Translation collapsed every run into the regular font | Validated `<s1..3>` pairs, variant selection, synthetic fallback tests |
+| Formula moves, overlaps, or exposes `{vN}` | Ordinary-font math was translated as prose or translator damaged placeholders | Formula regions, stacked fraction detection, safe tag round-trip tests |
+| Table labels stay English | Earlier pipeline protected the entire model table | Translate only matched cells; preserve unmatched tables and technical codes |
+| Paragraph crosses the right edge | Width budget ignored first-line indentation | `paragraph_width_budget()` regression |
+| Last table line crosses a row | Font shrank after ink was measured, or preserved code remained larger than prose | Recompute final ink, fit union, then shift inside cell bounds |
+| Bullets vanish on Mac or Windows | Office encoded Wingdings/Symbol bullets as PUA characters absent from Go Noto and Times New Roman | `is_bullet_character()` preserves the embedded dingbat glyph; preservation tests |
+| Translation service corrupts style/formula tags | Tags are translated, dropped, duplicated, or cross-nested | Reject segment, keep source, report partial; handoff translator tests |
+
+When adding a new guard, reproduce the smallest failing geometry in a unit test
+and validate the real document visually. Do not encode a filename-specific fix.

--- a/agent-knowledge/release.md
+++ b/agent-knowledge/release.md
@@ -1,0 +1,32 @@
+# Cross-Platform Build and Release
+
+Only publish when the user explicitly requests it. The authoritative version is
+`APP_VERSION` in `app/update.py`; a release tag must be exactly `v<APP_VERSION>`.
+The release workflow rejects a mismatch.
+
+## Local Gates
+
+- Run the complete validation gate in [validation.md](validation.md).
+- Windows: run `build.ps1`; verify `dist/PDFTranslate-windows.zip`, payload
+  files, SHA-256, and packaged `PDFTranslate.exe --smoke-test` exit code 0.
+- macOS builds require Darwin and the target architecture. `build-macos.sh`
+  builds/smoke-tests/signs the `.app`, creates a DMG, and verifies it.
+
+## GitHub Flow
+
+1. Commit only source, tests, docs, and version changes on a feature branch.
+2. Push, create/update a PR, review exact head SHA, and merge to `main`.
+3. Update local `main` with `--ff-only` and verify a clean worktree.
+4. Create and push the matching annotated `v*` tag.
+5. Wait for `.github/workflows/release.yml` to finish all jobs:
+   Windows, macOS Apple Silicon, macOS Intel, then publish.
+6. Verify the release is neither draft nor prerelease and contains exactly:
+   `PDFTranslate-windows.zip`, `PDFTranslate-macos-apple-silicon.dmg`, and
+   `PDFTranslate-macos-intel.dmg`.
+7. Download artifacts and compare local SHA-256 values with GitHub digests.
+
+`.github/workflows/macos-artifacts.yml` is an on-demand/branch build and does
+not replace the tag release gate. PyInstaller is not a cross-compiler; never
+claim a Windows-built Mac artifact was tested. Without a Developer ID,
+`build-macos.sh` applies an ad-hoc signature: users may need right-click → Open,
+and the DMG is not notarized.

--- a/agent-knowledge/repository.md
+++ b/agent-knowledge/repository.md
@@ -1,0 +1,52 @@
+# Repository and Development
+
+## Structure
+
+- `app/`: CustomTkinter GUI, update checks, UI fonts, icons, bundled assets.
+- `scripts/translate_pdf.py`: supported CLI and stable output staging.
+- `scripts/fetch_assets.py`: downloads the layout model and Unicode PDF font.
+- `pdf2zh/`: bundled extraction, translation, preservation, and PDF rendering.
+- `tests/`: standard-library `unittest` regressions.
+- `references/`: product preservation contract.
+- `app.spec`, `build.ps1`: Windows packaging.
+- `app-macos.spec`, `build-macos.sh`: native macOS packaging.
+- `.github/workflows/`: release and on-demand macOS builds.
+
+## Commands
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -r requirements-app.txt
+.\.venv\Scripts\python.exe app\gui.py
+.\.venv\Scripts\python.exe scripts\translate_pdf.py INPUT.pdf --output-dir OUT
+.\.venv\Scripts\python.exe -m unittest discover -s tests -v
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build.ps1
+```
+
+macOS:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -r requirements-app.txt
+.venv/bin/python app/gui.py
+.venv/bin/python scripts/translate_pdf.py INPUT.pdf --output-dir OUT
+.venv/bin/python -m unittest discover -s tests -v
+bash build-macos.sh
+```
+
+## Code and Tests
+
+Use four-space indentation, type annotations, concise docstrings,
+`snake_case`, `PascalCase`, and `UPPER_CASE`. Prefer `pathlib.Path`, explicit
+exceptions, and small helpers whose geometry can be unit-tested. Match nearby
+imports and style; there is no repository-wide formatter.
+
+Name tests `test_<feature>.py`, classes `<Feature>Tests`, and methods
+`test_<behavior>`. Test observable behavior rather than comments or exact
+implementation text. Preserve unrelated dirty-worktree changes.
+
+Commit subjects are short and imperative. PRs state user impact, validation,
+and representative visual evidence for GUI/PDF changes. Never commit local
+test PDFs or packaged artifacts.

--- a/agent-knowledge/validation.md
+++ b/agent-knowledge/validation.md
@@ -1,0 +1,34 @@
+# Validation and PDF QA
+
+## Automated Gate
+
+Run from the repository root with the platform virtual environment:
+
+```text
+python -m unittest discover -s tests -v
+python -m pip check
+python -m ruff check pdf2zh scripts app tests --select E9,F63,F7,F82
+```
+
+`git diff --check` must be clean. Run `app/gui.py --smoke-test`; after packaging,
+run the packaged executable with `--smoke-test` and require exit code 0.
+
+## PDF Gate
+
+Keep source and output hashes/paths separate. For every delivered PDF:
+
+1. Reopen it and require the same page count and canvas sizes as the source.
+2. Search extracted text for `{vN}`, `<bN>`, `<sN>`, `U+0000`, and `U+FFFD`.
+3. Check span boxes against the page canvas and cell text against detected cell
+   boundaries. Extraction is diagnostic, not proof of visual correctness.
+4. Render every page. Review contact sheets for global anomalies, then inspect
+   formula-, table-, rotation-, style-, first/middle/last-page regressions at
+   readable resolution.
+5. Confirm formulas, technical identifiers, URLs, figures, borders, bullets,
+   bold/italic runs, and page numbers remain legible and correctly placed.
+6. Report every fallback segment or materially untranslated region as partial.
+
+Use `tmp/pdfs/` for render/diagnostic intermediates and `output/pdf/` for final
+PDFs. Never overwrite a source or an existing user output without explicit
+authorization. For expensive translations, validate representative pages
+first, then regenerate the complete document with the final code.


### PR DESCRIPTION
## Summary
- track concise `AGENTS.md` and `CLAUDE.md` entrypoints backed by one shared `agent-knowledge/` directory
- split repository, PDF-engine, regression, validation, and release knowledge into focused Markdown files
- add a project-scoped Claude Code adapter at `.claude/skills/pdf-translate/SKILL.md`, automatically discoverable on macOS after clone/pull
- route the canonical root `SKILL.md` to the same shared knowledge
- keep personal Claude overrides ignored while allowing shared agent instructions to be versioned

## Validation
- skill-creator `quick_validate.py` passed for both the root and Claude adapter skills
- all relative Markdown links resolve
- `AGENTS.md` remains concise (226 words)
- `git diff --check` passed

Documentation/agent configuration only; no runtime or release version changes.